### PR TITLE
Fix/cjk line wrapping

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -27,15 +27,19 @@
 	"scripts": {
 		"build": "vite build",
 		"dev": "vite build --watch",
-		"typecheck": "tsc --noEmit"
+		"typecheck": "tsc --noEmit",
+		"test": "vitest run",
+		"test:watch": "vitest"
 	},
 	"dependencies": {
 		"@braccato/parsers": "workspace:^",
 		"lit": "^3.2.1"
 	},
 	"devDependencies": {
+		"jsdom": "^28.1.0",
 		"typescript": "^5.7.3",
 		"vite": "^6.0.7",
-		"vite-plugin-dts": "^4.3.0"
+		"vite-plugin-dts": "^4.3.0",
+		"vitest": "^3.0.4"
 	}
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@braccato/core",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"description": "Synchronized lyrics web component with word-by-word animations",
 	"type": "module",
 	"license": "MIT",

--- a/packages/core/src/__tests__/renderer.test.ts
+++ b/packages/core/src/__tests__/renderer.test.ts
@@ -9,7 +9,9 @@ function makeLyric(words: string): Lyric {
 describe("renderLyrics", () => {
 	it("produces multiple wrappable group spans for a space-less Japanese line", () => {
 		const container = document.createElement("div");
-		const lyrics: Lyric[] = [makeLyric("これはとても長い日本語の歌詞でスペースが入っていないため横幅を超えたときに自然改行されてほしい")];
+		const lyrics: Lyric[] = [
+			makeLyric("これはとても長い日本語の歌詞でスペースが入っていないため横幅を超えたときに自然改行されてほしい"),
+		];
 
 		renderLyrics(lyrics, container);
 

--- a/packages/core/src/__tests__/renderer.test.ts
+++ b/packages/core/src/__tests__/renderer.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+import { renderLyrics } from "../renderer.js";
+import type { Lyric } from "../types.js";
+
+function makeLyric(words: string): Lyric {
+	return { startTimeMs: 0, words, durationMs: 1000 };
+}
+
+describe("renderLyrics", () => {
+	it("produces multiple wrappable group spans for a space-less Japanese line", () => {
+		const container = document.createElement("div");
+		const lyrics: Lyric[] = [makeLyric("これはとても長い日本語の歌詞でスペースが入っていないため横幅を超えたときに自然改行されてほしい")];
+
+		renderLyrics(lyrics, container);
+
+		const line = container.querySelector(".braccato--line") as HTMLDivElement;
+		expect(line).toBeTruthy();
+		const groupSpans = line.querySelectorAll(":scope > span");
+		expect(groupSpans.length).toBeGreaterThan(1);
+	});
+
+	it("produces multiple wrappable group spans for a space-separated English line", () => {
+		const container = document.createElement("div");
+		const lyrics: Lyric[] = [makeLyric("the quick brown fox jumps over the lazy dog")];
+
+		renderLyrics(lyrics, container);
+
+		const line = container.querySelector(".braccato--line") as HTMLDivElement;
+		const groupSpans = line.querySelectorAll(":scope > span");
+		expect(groupSpans.length).toBeGreaterThan(1);
+	});
+
+	it("applies the trailing-space class on the last sub-part of source parts that end in whitespace", () => {
+		const container = document.createElement("div");
+		const lyrics: Lyric[] = [
+			{
+				startTimeMs: 0,
+				durationMs: 1000,
+				words: "hello world",
+				parts: [
+					{ startTimeMs: 0, words: "hello ", durationMs: 500 },
+					{ startTimeMs: 500, words: "world", durationMs: 500 },
+				],
+			},
+		];
+
+		renderLyrics(lyrics, container);
+
+		const line = container.querySelector(".braccato--line") as HTMLDivElement;
+		const trailing = line.querySelectorAll(".braccato--has-trailing-space");
+		expect(trailing.length).toBeGreaterThanOrEqual(1);
+	});
+
+	it("does not apply trailing-space class on the final source part with no trailing whitespace", () => {
+		const container = document.createElement("div");
+		const lyrics: Lyric[] = [
+			{
+				startTimeMs: 0,
+				durationMs: 1000,
+				words: "hello world",
+				parts: [
+					{ startTimeMs: 0, words: "hello ", durationMs: 500 },
+					{ startTimeMs: 500, words: "world", durationMs: 500 },
+				],
+			},
+		];
+
+		renderLyrics(lyrics, container);
+
+		const line = container.querySelector(".braccato--line") as HTMLDivElement;
+		const wordSpans = Array.from(line.querySelectorAll(".braccato--word")) as HTMLSpanElement[];
+		const worldSpan = wordSpans.find((s) => s.textContent === "world");
+		expect(worldSpan?.classList.contains("braccato--has-trailing-space")).toBe(false);
+	});
+});

--- a/packages/core/src/__tests__/renderer.test.ts
+++ b/packages/core/src/__tests__/renderer.test.ts
@@ -32,7 +32,7 @@ describe("renderLyrics", () => {
 		expect(groupSpans.length).toBeGreaterThan(1);
 	});
 
-	it("applies the trailing-space class on the last sub-part of source parts that end in whitespace", () => {
+	it("does not segment English word parts (one word span per source part)", () => {
 		const container = document.createElement("div");
 		const lyrics: Lyric[] = [
 			{
@@ -49,29 +49,29 @@ describe("renderLyrics", () => {
 		renderLyrics(lyrics, container);
 
 		const line = container.querySelector(".braccato--line") as HTMLDivElement;
-		const trailing = line.querySelectorAll(".braccato--has-trailing-space");
-		expect(trailing.length).toBeGreaterThanOrEqual(1);
+		const wordSpans = line.querySelectorAll(".braccato--word");
+		expect(wordSpans.length).toBe(2);
+		expect(wordSpans[0].textContent).toBe("hello ");
+		expect(wordSpans[1].textContent).toBe("world");
 	});
 
-	it("does not apply trailing-space class on the final source part with no trailing whitespace", () => {
+	it("does not add splitter wrap markers to short English parts", () => {
 		const container = document.createElement("div");
 		const lyrics: Lyric[] = [
 			{
 				startTimeMs: 0,
 				durationMs: 1000,
-				words: "hello world",
-				parts: [
-					{ startTimeMs: 0, words: "hello ", durationMs: 500 },
-					{ startTimeMs: 500, words: "world", durationMs: 500 },
-				],
+				words: "hello",
+				parts: [{ startTimeMs: 0, words: "hello", durationMs: 1000 }],
 			},
 		];
 
 		renderLyrics(lyrics, container);
 
 		const line = container.querySelector(".braccato--line") as HTMLDivElement;
-		const wordSpans = Array.from(line.querySelectorAll(".braccato--word")) as HTMLSpanElement[];
-		const worldSpan = wordSpans.find((s) => s.textContent === "world");
-		expect(worldSpan?.classList.contains("braccato--has-trailing-space")).toBe(false);
+		const wordSpans = line.querySelectorAll(".braccato--word");
+		for (const span of wordSpans) {
+			expect((span as HTMLElement).dataset.wrapAfter).toBeUndefined();
+		}
 	});
 });

--- a/packages/core/src/__tests__/renderer.test.ts
+++ b/packages/core/src/__tests__/renderer.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from "vitest";
 import { renderLyrics } from "../renderer.js";
 import type { Lyric } from "../types.js";
 
+const GROUP_SELECTOR = ":scope > span:not(.braccato--break)";
+
 function makeLyric(words: string): Lyric {
 	return { startTimeMs: 0, words, durationMs: 1000 };
 }
 
 describe("renderLyrics", () => {
-	it("produces multiple wrappable group spans for a space-less Japanese line", () => {
+	it("wraps a long space-less Japanese line by producing many group spans", () => {
 		const container = document.createElement("div");
 		const lyrics: Lyric[] = [
 			makeLyric("これはとても長い日本語の歌詞でスペースが入っていないため横幅を超えたときに自然改行されてほしい"),
@@ -17,19 +19,19 @@ describe("renderLyrics", () => {
 
 		const line = container.querySelector(".braccato--line") as HTMLDivElement;
 		expect(line).toBeTruthy();
-		const groupSpans = line.querySelectorAll(":scope > span");
-		expect(groupSpans.length).toBeGreaterThan(1);
+		const groupSpans = line.querySelectorAll(GROUP_SELECTOR);
+		expect(groupSpans.length).toBeGreaterThanOrEqual(5);
 	});
 
-	it("produces multiple wrappable group spans for a space-separated English line", () => {
+	it("preserves per-word grouping for a space-separated English line", () => {
 		const container = document.createElement("div");
 		const lyrics: Lyric[] = [makeLyric("the quick brown fox jumps over the lazy dog")];
 
 		renderLyrics(lyrics, container);
 
 		const line = container.querySelector(".braccato--line") as HTMLDivElement;
-		const groupSpans = line.querySelectorAll(":scope > span");
-		expect(groupSpans.length).toBeGreaterThan(1);
+		const groupSpans = line.querySelectorAll(GROUP_SELECTOR);
+		expect(groupSpans.length).toBe(9);
 	});
 
 	it("does not segment English word parts (one word span per source part)", () => {
@@ -73,5 +75,23 @@ describe("renderLyrics", () => {
 		for (const span of wordSpans) {
 			expect((span as HTMLElement).dataset.wrapAfter).toBeUndefined();
 		}
+	});
+
+	it("wraps a long Japanese line emitted via richsync parts (no whitespace, no trailing space)", () => {
+		const container = document.createElement("div");
+		const lyrics: Lyric[] = [
+			{
+				startTimeMs: 0,
+				durationMs: 1000,
+				words: "これはとても長い日本語の歌詞です",
+				parts: [{ startTimeMs: 0, words: "これはとても長い日本語の歌詞です", durationMs: 1000 }],
+			},
+		];
+
+		renderLyrics(lyrics, container);
+
+		const line = container.querySelector(".braccato--line") as HTMLDivElement;
+		const groupSpans = line.querySelectorAll(GROUP_SELECTOR);
+		expect(groupSpans.length).toBeGreaterThanOrEqual(5);
 	});
 });

--- a/packages/core/src/__tests__/split-part.test.ts
+++ b/packages/core/src/__tests__/split-part.test.ts
@@ -6,38 +6,35 @@ describe("splitPart", () => {
 		vi.restoreAllMocks();
 	});
 
-	it("segments an English sentence at word boundaries", () => {
-		const result = splitPart({
-			startTimeMs: 1000,
-			words: "hello world",
-			durationMs: 2000,
-		});
-
-		const text = result.map((p) => p.words).join("");
-		expect(text).toBe("hello world");
-		expect(result.length).toBeGreaterThanOrEqual(2);
-		expect(result.some((p) => p.words === "hello")).toBe(true);
-		expect(result.some((p) => p.words === "world")).toBe(true);
+	it("does not split short English words", () => {
+		const result = splitPart({ startTimeMs: 0, words: "hello", durationMs: 100 });
+		expect(result).toHaveLength(1);
+		expect(result[0].words).toBe("hello");
+		expect(result[0].isWrapAfter).toBe(false);
 	});
 
-	it("segments a space-less Japanese line into multiple sub-parts", () => {
+	it("does not split parts containing whitespace", () => {
+		const result = splitPart({ startTimeMs: 0, words: "hello world", durationMs: 100 });
+		expect(result).toHaveLength(1);
+		expect(result[0].words).toBe("hello world");
+	});
+
+	it("does not split parts containing dash punctuation", () => {
+		const result = splitPart({ startTimeMs: 0, words: "well-being", durationMs: 100 });
+		expect(result).toHaveLength(1);
+		expect(result[0].words).toBe("well-being");
+	});
+
+	it("segments a long space-less Japanese line into multiple sub-parts", () => {
 		const input = "これはとても長い日本語の歌詞です";
-		const result = splitPart({
-			startTimeMs: 0,
-			words: input,
-			durationMs: 1000,
-		});
+		const result = splitPart({ startTimeMs: 0, words: input, durationMs: 1000 });
 
 		expect(result.length).toBeGreaterThan(1);
 		expect(result.map((p) => p.words).join("")).toBe(input);
 	});
 
 	it("marks isWrapAfter true on all sub-parts except the last", () => {
-		const result = splitPart({
-			startTimeMs: 0,
-			words: "alpha beta gamma",
-			durationMs: 300,
-		});
+		const result = splitPart({ startTimeMs: 0, words: "これはとても長い日本語の歌詞です", durationMs: 300 });
 
 		expect(result.length).toBeGreaterThan(1);
 		for (let i = 0; i < result.length - 1; i++) {
@@ -47,7 +44,7 @@ describe("splitPart", () => {
 	});
 
 	it("interpolates timings so sub-parts span the parent duration", () => {
-		const parent = { startTimeMs: 500, words: "one two three four", durationMs: 1200 };
+		const parent = { startTimeMs: 500, words: "これはとても長い日本語の歌詞です", durationMs: 1200 };
 		const result = splitPart(parent);
 
 		const totalDuration = result.reduce((sum, p) => sum + p.durationMs, 0);
@@ -60,7 +57,6 @@ describe("splitPart", () => {
 	});
 
 	it("falls back to code-point split when Intl.Segmenter throws", () => {
-		const SegmenterCtor = Intl.Segmenter;
 		vi.stubGlobal(
 			"Intl",
 			new Proxy(Intl, {
@@ -77,20 +73,15 @@ describe("splitPart", () => {
 			}),
 		);
 
-		const result = splitPart({
-			startTimeMs: 0,
-			words: "abc",
-			durationMs: 30,
-		});
+		const result = splitPart({ startTimeMs: 0, words: "あいうえおかきくけこ", durationMs: 100 });
 
-		expect(result.map((p) => p.words)).toEqual(["a", "b", "c"]);
-		expect(SegmenterCtor).toBeDefined();
+		expect(result.map((p) => p.words)).toEqual(["あ", "い", "う", "え", "お", "か", "き", "く", "け", "こ"]);
 	});
 
 	it("propagates isBackground from parent to every sub-part", () => {
 		const result = splitPart({
 			startTimeMs: 0,
-			words: "ooh ooh",
+			words: "これはとても長い日本語の歌詞です",
 			durationMs: 200,
 			isBackground: true,
 		});
@@ -99,17 +90,5 @@ describe("splitPart", () => {
 		for (const sub of result) {
 			expect(sub.isBackground).toBe(true);
 		}
-	});
-
-	it("yields a single sub-part with isWrapAfter=false for single-character input", () => {
-		const result = splitPart({
-			startTimeMs: 0,
-			words: "あ",
-			durationMs: 100,
-		});
-
-		expect(result).toHaveLength(1);
-		expect(result[0].isWrapAfter).toBe(false);
-		expect(result[0].words).toBe("あ");
 	});
 });

--- a/packages/core/src/__tests__/split-part.test.ts
+++ b/packages/core/src/__tests__/split-part.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { splitPart } from "../split-part.js";
+
+describe("splitPart", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("segments an English sentence at word boundaries", () => {
+		const result = splitPart({
+			startTimeMs: 1000,
+			words: "hello world",
+			durationMs: 2000,
+		});
+
+		const text = result.map((p) => p.words).join("");
+		expect(text).toBe("hello world");
+		expect(result.length).toBeGreaterThanOrEqual(2);
+		expect(result.some((p) => p.words === "hello")).toBe(true);
+		expect(result.some((p) => p.words === "world")).toBe(true);
+	});
+
+	it("segments a space-less Japanese line into multiple sub-parts", () => {
+		const input = "これはとても長い日本語の歌詞です";
+		const result = splitPart({
+			startTimeMs: 0,
+			words: input,
+			durationMs: 1000,
+		});
+
+		expect(result.length).toBeGreaterThan(1);
+		expect(result.map((p) => p.words).join("")).toBe(input);
+	});
+
+	it("marks isWrapAfter true on all sub-parts except the last", () => {
+		const result = splitPart({
+			startTimeMs: 0,
+			words: "alpha beta gamma",
+			durationMs: 300,
+		});
+
+		expect(result.length).toBeGreaterThan(1);
+		for (let i = 0; i < result.length - 1; i++) {
+			expect(result[i].isWrapAfter).toBe(true);
+		}
+		expect(result[result.length - 1].isWrapAfter).toBe(false);
+	});
+
+	it("interpolates timings so sub-parts span the parent duration", () => {
+		const parent = { startTimeMs: 500, words: "one two three four", durationMs: 1200 };
+		const result = splitPart(parent);
+
+		const totalDuration = result.reduce((sum, p) => sum + p.durationMs, 0);
+		expect(Math.abs(totalDuration - parent.durationMs)).toBeLessThanOrEqual(1);
+		expect(result[0].startTimeMs).toBe(parent.startTimeMs);
+
+		for (let i = 1; i < result.length; i++) {
+			expect(result[i].startTimeMs).toBeGreaterThan(result[i - 1].startTimeMs);
+		}
+	});
+
+	it("marks hasTrailingSpace on segments ending in whitespace", () => {
+		const result = splitPart({
+			startTimeMs: 0,
+			words: "hello world",
+			durationMs: 100,
+		});
+
+		const helloPart = result.find((p) => p.words === "hello");
+		const spacePart = result.find((p) => /\s/.test(p.words));
+		expect(spacePart?.hasTrailingSpace).toBe(true);
+		expect(helloPart?.hasTrailingSpace).toBe(false);
+	});
+
+	it("falls back to code-point split when Intl.Segmenter throws", () => {
+		const SegmenterCtor = Intl.Segmenter;
+		vi.stubGlobal(
+			"Intl",
+			new Proxy(Intl, {
+				get(target, prop) {
+					if (prop === "Segmenter") {
+						return class {
+							constructor() {
+								throw new Error("not supported");
+							}
+						};
+					}
+					return Reflect.get(target, prop);
+				},
+			}),
+		);
+
+		const result = splitPart({
+			startTimeMs: 0,
+			words: "abc",
+			durationMs: 30,
+		});
+
+		expect(result.map((p) => p.words)).toEqual(["a", "b", "c"]);
+		expect(SegmenterCtor).toBeDefined();
+	});
+
+	it("propagates isBackground from parent to every sub-part", () => {
+		const result = splitPart({
+			startTimeMs: 0,
+			words: "ooh ooh",
+			durationMs: 200,
+			isBackground: true,
+		});
+
+		expect(result.length).toBeGreaterThan(0);
+		for (const sub of result) {
+			expect(sub.isBackground).toBe(true);
+		}
+	});
+
+	it("yields a single sub-part with isWrapAfter=false for single-character input", () => {
+		const result = splitPart({
+			startTimeMs: 0,
+			words: "あ",
+			durationMs: 100,
+		});
+
+		expect(result).toHaveLength(1);
+		expect(result[0].isWrapAfter).toBe(false);
+		expect(result[0].words).toBe("あ");
+	});
+});

--- a/packages/core/src/__tests__/split-part.test.ts
+++ b/packages/core/src/__tests__/split-part.test.ts
@@ -13,7 +13,7 @@ describe("splitPart", () => {
 		expect(result[0].isWrapAfter).toBe(false);
 	});
 
-	it("does not split parts containing whitespace", () => {
+	it("does not split parts containing internal whitespace", () => {
 		const result = splitPart({ startTimeMs: 0, words: "hello world", durationMs: 100 });
 		expect(result).toHaveLength(1);
 		expect(result[0].words).toBe("hello world");
@@ -27,6 +27,14 @@ describe("splitPart", () => {
 
 	it("segments a long space-less Japanese line into multiple sub-parts", () => {
 		const input = "これはとても長い日本語の歌詞です";
+		const result = splitPart({ startTimeMs: 0, words: input, durationMs: 1000 });
+
+		expect(result.length).toBeGreaterThan(1);
+		expect(result.map((p) => p.words).join("")).toBe(input);
+	});
+
+	it("ignores trailing whitespace when deciding whether to split", () => {
+		const input = "これはとても長い日本語の歌詞です ";
 		const result = splitPart({ startTimeMs: 0, words: input, durationMs: 1000 });
 
 		expect(result.length).toBeGreaterThan(1);

--- a/packages/core/src/__tests__/split-part.test.ts
+++ b/packages/core/src/__tests__/split-part.test.ts
@@ -59,19 +59,6 @@ describe("splitPart", () => {
 		}
 	});
 
-	it("marks hasTrailingSpace on segments ending in whitespace", () => {
-		const result = splitPart({
-			startTimeMs: 0,
-			words: "hello world",
-			durationMs: 100,
-		});
-
-		const helloPart = result.find((p) => p.words === "hello");
-		const spacePart = result.find((p) => /\s/.test(p.words));
-		expect(spacePart?.hasTrailingSpace).toBe(true);
-		expect(helloPart?.hasTrailingSpace).toBe(false);
-	});
-
 	it("falls back to code-point split when Intl.Segmenter throws", () => {
 		const SegmenterCtor = Intl.Segmenter;
 		vi.stubGlobal(

--- a/packages/core/src/__tests__/split-part.test.ts
+++ b/packages/core/src/__tests__/split-part.test.ts
@@ -41,6 +41,14 @@ describe("splitPart", () => {
 		expect(result.map((p) => p.words).join("")).toBe(input);
 	});
 
+	it("falls back to grapheme granularity when word granularity returns one segment", () => {
+		const input = "한국어가사도공백없이쭉이어지면자동으로줄바꿈이일어나야합니다";
+		const result = splitPart({ startTimeMs: 0, words: input, durationMs: 1000 });
+
+		expect(result.length).toBeGreaterThan(1);
+		expect(result.map((p) => p.words).join("")).toBe(input);
+	});
+
 	it("marks isWrapAfter true on all sub-parts except the last", () => {
 		const result = splitPart({ startTimeMs: 0, words: "これはとても長い日本語の歌詞です", durationMs: 300 });
 

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -1,5 +1,6 @@
 import { createInstrumentalElement } from "./create-instrumental-element.js";
 import { testRtl } from "./rtl.js";
+import { splitPart } from "./split-part.js";
 import type { LineData, Lyric, LyricPart, LyricsData, PartData, SyncType } from "./types.js";
 
 // -- CSS Class Constants --------------------------
@@ -12,6 +13,7 @@ const RTL_CLASS = "braccato-rtl";
 const ZERO_DUR_CLASS = "braccato-zero-dur-animate";
 const ROMANIZED_CLASS = "braccato--romanized";
 const TRANSLATED_CLASS = "braccato--translated";
+const TRAILING_SPACE_CLASS = "braccato--has-trailing-space";
 
 // -- Helpers --------------------------
 
@@ -43,7 +45,6 @@ function createBreakElem(parent: HTMLElement, order: number): void {
 }
 
 function groupByWordAndInsert(parent: HTMLElement, buffer: HTMLSpanElement[]): void {
-	const breakChar = /([\s\u200B\u00AD\p{Dash_Punctuation}])/gu;
 	let wordGroupBuffer: HTMLSpanElement[] = [];
 	let isCurrentBufferBg = false;
 
@@ -58,22 +59,16 @@ function groupByWordAndInsert(parent: HTMLElement, buffer: HTMLSpanElement[]): v
 	};
 
 	for (const part of buffer) {
-		const isNonMatchingType = isCurrentBufferBg !== part.classList.contains(BG_CLASS);
-		const isElmJustSpace = !(part.textContent!.length === 1 && part.textContent![0] === " ");
-
-		if (!isNonMatchingType) wordGroupBuffer.push(part);
-
-		if (
-			(part.textContent!.length > 0 && breakChar.test(part.textContent![part.textContent!.length - 1])) ||
-			isNonMatchingType
-		) {
+		const partIsBg = part.classList.contains(BG_CLASS);
+		if (isCurrentBufferBg !== partIsBg) {
 			flush();
+			isCurrentBufferBg = partIsBg;
 		}
+		wordGroupBuffer.push(part);
 
-		if (isNonMatchingType && isElmJustSpace) {
-			wordGroupBuffer.push(part);
-			isCurrentBufferBg = part.classList.contains(BG_CLASS);
-		}
+		const hasTrailingSpace = part.classList.contains(TRAILING_SPACE_CLASS);
+		const wrapAfter = part.dataset.wrapAfter === "true";
+		if (hasTrailingSpace || wrapAfter) flush();
 	}
 	flush();
 }
@@ -91,32 +86,42 @@ function buildWordSpans(parts: LyricPart[], line: LineData, container: HTMLEleme
 			rtlBuffer = [];
 		}
 
-		const span = document.createElement("span");
-		span.classList.add(WORD_CLASS);
-		if (part.durationMs === 0) span.classList.add(ZERO_DUR_CLASS);
-		if (isRtl) span.classList.add(RTL_CLASS);
+		const sourceHasTrailingSpace = /\s$/.test(part.words);
+		const subParts = splitPart(part);
 
-		const partData: PartData = {
-			time: part.startTimeMs / 1000,
-			duration: part.durationMs / 1000,
-			element: span,
-			animationStartTimeMs: Number.POSITIVE_INFINITY,
-		};
+		for (let i = 0; i < subParts.length; i++) {
+			const sub = subParts[i];
+			const isLast = i === subParts.length - 1;
 
-		span.textContent = part.words;
-		span.dataset.time = String(partData.time);
-		span.dataset.duration = String(partData.duration);
-		span.dataset.content = part.words;
-		span.style.setProperty("--braccato-duration", `${part.durationMs}ms`);
-		if (part.durationMs > longWordThreshold) span.dataset.longWord = "true";
-		if (part.isBackground) span.classList.add(BG_CLASS);
-		if (part.words.trim().length === 0) span.style.display = "inline";
-		if (part.words.trim().length !== 0) line.parts.push(partData);
+			const span = document.createElement("span");
+			span.classList.add(WORD_CLASS);
+			if (sub.durationMs === 0) span.classList.add(ZERO_DUR_CLASS);
+			if (isRtl) span.classList.add(RTL_CLASS);
 
-		if (isRtl) {
-			rtlBuffer.push(span);
-		} else {
-			elemBuffer.push(span);
+			const partData: PartData = {
+				time: sub.startTimeMs / 1000,
+				duration: sub.durationMs / 1000,
+				element: span,
+				animationStartTimeMs: Number.POSITIVE_INFINITY,
+			};
+
+			span.textContent = sub.words;
+			span.dataset.time = String(partData.time);
+			span.dataset.duration = String(partData.duration);
+			span.dataset.content = sub.words;
+			span.style.setProperty("--braccato-duration", `${sub.durationMs}ms`);
+			if (sub.durationMs > longWordThreshold) span.dataset.longWord = "true";
+			if (sub.isBackground) span.classList.add(BG_CLASS);
+			if (sub.isWrapAfter) span.dataset.wrapAfter = "true";
+			if (isLast && sourceHasTrailingSpace) span.classList.add(TRAILING_SPACE_CLASS);
+			if (sub.words.trim().length === 0) span.style.display = "inline";
+			if (sub.words.trim().length !== 0) line.parts.push(partData);
+
+			if (isRtl) {
+				rtlBuffer.push(span);
+			} else {
+				elemBuffer.push(span);
+			}
 		}
 	}
 

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -13,7 +13,8 @@ const RTL_CLASS = "braccato-rtl";
 const ZERO_DUR_CLASS = "braccato-zero-dur-animate";
 const ROMANIZED_CLASS = "braccato--romanized";
 const TRANSLATED_CLASS = "braccato--translated";
-const TRAILING_SPACE_CLASS = "braccato--has-trailing-space";
+
+const BREAK_CHAR_RE = /[\s​­\p{Dash_Punctuation}]/u;
 
 // -- Helpers --------------------------
 
@@ -66,9 +67,10 @@ function groupByWordAndInsert(parent: HTMLElement, buffer: HTMLSpanElement[]): v
 		}
 		wordGroupBuffer.push(part);
 
-		const hasTrailingSpace = part.classList.contains(TRAILING_SPACE_CLASS);
+		const text = part.textContent ?? "";
+		const endsOnBreak = text.length > 0 && BREAK_CHAR_RE.test(text[text.length - 1]);
 		const wrapAfter = part.dataset.wrapAfter === "true";
-		if (hasTrailingSpace || wrapAfter) flush();
+		if (endsOnBreak || wrapAfter) flush();
 	}
 	flush();
 }
@@ -86,13 +88,9 @@ function buildWordSpans(parts: LyricPart[], line: LineData, container: HTMLEleme
 			rtlBuffer = [];
 		}
 
-		const sourceHasTrailingSpace = /\s$/.test(part.words);
 		const subParts = splitPart(part);
 
-		for (let i = 0; i < subParts.length; i++) {
-			const sub = subParts[i];
-			const isLast = i === subParts.length - 1;
-
+		for (const sub of subParts) {
 			const span = document.createElement("span");
 			span.classList.add(WORD_CLASS);
 			if (sub.durationMs === 0) span.classList.add(ZERO_DUR_CLASS);
@@ -113,7 +111,6 @@ function buildWordSpans(parts: LyricPart[], line: LineData, container: HTMLEleme
 			if (sub.durationMs > longWordThreshold) span.dataset.longWord = "true";
 			if (sub.isBackground) span.classList.add(BG_CLASS);
 			if (sub.isWrapAfter) span.dataset.wrapAfter = "true";
-			if (isLast && sourceHasTrailingSpace) span.classList.add(TRAILING_SPACE_CLASS);
 			if (sub.words.trim().length === 0) span.style.display = "inline";
 			if (sub.words.trim().length !== 0) line.parts.push(partData);
 

--- a/packages/core/src/split-part.ts
+++ b/packages/core/src/split-part.ts
@@ -2,7 +2,6 @@ import type { LyricPart } from "@braccato/parsers";
 
 export interface SplitSubPart extends LyricPart {
 	isWrapAfter: boolean;
-	hasTrailingSpace: boolean;
 }
 
 function segment(text: string): string[] {
@@ -24,7 +23,6 @@ export function splitPart(part: LyricPart): SplitSubPart[] {
 				words: part.words,
 				isBackground: part.isBackground,
 				isWrapAfter: false,
-				hasTrailingSpace: /\s$/.test(part.words),
 			},
 		];
 	}
@@ -36,6 +34,5 @@ export function splitPart(part: LyricPart): SplitSubPart[] {
 		words: seg,
 		isBackground: part.isBackground,
 		isWrapAfter: i < segments.length - 1,
-		hasTrailingSpace: /\s$/.test(seg),
 	}));
 }

--- a/packages/core/src/split-part.ts
+++ b/packages/core/src/split-part.ts
@@ -1,0 +1,41 @@
+import type { LyricPart } from "@braccato/parsers";
+
+export interface SplitSubPart extends LyricPart {
+	isWrapAfter: boolean;
+	hasTrailingSpace: boolean;
+}
+
+function segment(text: string): string[] {
+	try {
+		const segmenter = new Intl.Segmenter(undefined, { granularity: "word" });
+		return Array.from(segmenter.segment(text), (s) => s.segment);
+	} catch {
+		return Array.from(text);
+	}
+}
+
+export function splitPart(part: LyricPart): SplitSubPart[] {
+	const segments = segment(part.words);
+	if (segments.length === 0) {
+		return [
+			{
+				startTimeMs: part.startTimeMs,
+				durationMs: part.durationMs,
+				words: part.words,
+				isBackground: part.isBackground,
+				isWrapAfter: false,
+				hasTrailingSpace: /\s$/.test(part.words),
+			},
+		];
+	}
+
+	const perDuration = part.durationMs / segments.length;
+	return segments.map((seg, i) => ({
+		startTimeMs: part.startTimeMs + i * perDuration,
+		durationMs: perDuration,
+		words: seg,
+		isBackground: part.isBackground,
+		isWrapAfter: i < segments.length - 1,
+		hasTrailingSpace: /\s$/.test(seg),
+	}));
+}

--- a/packages/core/src/split-part.ts
+++ b/packages/core/src/split-part.ts
@@ -16,8 +16,12 @@ function shouldSplit(text: string): boolean {
 
 function segment(text: string): string[] {
 	try {
-		const segmenter = new Intl.Segmenter(undefined, { granularity: "word" });
-		return Array.from(segmenter.segment(text), (s) => s.segment);
+		const wordSeg = new Intl.Segmenter(undefined, { granularity: "word" });
+		const words = Array.from(wordSeg.segment(text), (s) => s.segment);
+		if (words.length > 1) return words;
+
+		const graphSeg = new Intl.Segmenter(undefined, { granularity: "grapheme" });
+		return Array.from(graphSeg.segment(text), (s) => s.segment);
 	} catch {
 		return Array.from(text);
 	}

--- a/packages/core/src/split-part.ts
+++ b/packages/core/src/split-part.ts
@@ -4,6 +4,14 @@ export interface SplitSubPart extends LyricPart {
 	isWrapAfter: boolean;
 }
 
+const BREAK_CHAR_RE = /[\s​­\p{Dash_Punctuation}]/u;
+const SEGMENT_LENGTH_THRESHOLD = 5;
+
+function shouldSplit(text: string): boolean {
+	if (text.length <= SEGMENT_LENGTH_THRESHOLD) return false;
+	return !BREAK_CHAR_RE.test(text);
+}
+
 function segment(text: string): string[] {
 	try {
 		const segmenter = new Intl.Segmenter(undefined, { granularity: "word" });
@@ -14,17 +22,13 @@ function segment(text: string): string[] {
 }
 
 export function splitPart(part: LyricPart): SplitSubPart[] {
+	if (!shouldSplit(part.words)) {
+		return [{ ...part, isWrapAfter: false }];
+	}
+
 	const segments = segment(part.words);
-	if (segments.length === 0) {
-		return [
-			{
-				startTimeMs: part.startTimeMs,
-				durationMs: part.durationMs,
-				words: part.words,
-				isBackground: part.isBackground,
-				isWrapAfter: false,
-			},
-		];
+	if (segments.length <= 1) {
+		return [{ ...part, isWrapAfter: false }];
 	}
 
 	const perDuration = part.durationMs / segments.length;

--- a/packages/core/src/split-part.ts
+++ b/packages/core/src/split-part.ts
@@ -5,11 +5,13 @@ export interface SplitSubPart extends LyricPart {
 }
 
 const BREAK_CHAR_RE = /[\s​­\p{Dash_Punctuation}]/u;
+const TRAILING_WS_RE = /\s+$/;
 const SEGMENT_LENGTH_THRESHOLD = 5;
 
 function shouldSplit(text: string): boolean {
-	if (text.length <= SEGMENT_LENGTH_THRESHOLD) return false;
-	return !BREAK_CHAR_RE.test(text);
+	const core = text.replace(TRAILING_WS_RE, "");
+	if (core.length <= SEGMENT_LENGTH_THRESHOLD) return false;
+	return !BREAK_CHAR_RE.test(core);
 }
 
 function segment(text: string): string[] {

--- a/packages/core/src/styles/lyrics.css
+++ b/packages/core/src/styles/lyrics.css
@@ -129,11 +129,6 @@
   display: inline-block;
   transform: translateY(0px);
   position: relative;
-  margin-right: -0.25em;
-}
-
-.braccato--has-trailing-space {
-  margin-right: 0.25em;
 }
 
 .braccato--line.braccato--pre-animating,

--- a/packages/core/src/styles/lyrics.css
+++ b/packages/core/src/styles/lyrics.css
@@ -129,6 +129,11 @@
   display: inline-block;
   transform: translateY(0px);
   position: relative;
+  margin-right: -0.25em;
+}
+
+.braccato--has-trailing-space {
+  margin-right: 0.25em;
 }
 
 .braccato--line.braccato--pre-animating,

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	test: {
+		globals: true,
+		environment: "jsdom",
+	},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
         specifier: ^3.2.1
         version: 3.3.2
     devDependencies:
+      jsdom:
+        specifier: ^28.1.0
+        version: 28.1.0
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -36,6 +39,9 @@ importers:
       vite-plugin-dts:
         specifier: ^4.3.0
         version: 4.5.4(rollup@4.59.0)(typescript@5.9.3)(vite@6.4.1)
+      vitest:
+        specifier: ^3.0.4
+        version: 3.2.4(jsdom@28.1.0)
 
   packages/parsers:
     devDependencies:


### PR DESCRIPTION
## Overview

- Fixes #2 - Wrap space-less scripts (Japanese, Chinese, Thai, Lao, Khmer, Myanmar, Tibetan) by segmenting long unbroken parts via `Intl.Segmenter` with `granularity: "word"`, falling back to `"grapheme"` when word granularity returns one segment (Korean, Arabic, Hebrew, long compound Latin).


