### PR TITLE
feat(core): scale song animations by the playback rate

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -81,7 +81,7 @@ connects, and everything it was handed by then is applied at once.
 | `mediaElement`  |                | `HTMLMediaElement \| null` (get)    | `null`   | What `source` resolved to. Null while disconnected, and null for a selector that missed.                                                   |
 | `currentTime`   | `current-time` | `number`                            | `0`      | Playback position in **seconds**. Writing it renders the view again, so whoever holds the clock drives the lyrics by writing this.        |
 | `playing`       | `playing`      | `boolean`                           | `false`  | A paused view animates differently from a playing one.                                                                                     |
-| `tickOptions`   |                | `ElementTickOptions`                | `{}`     | The rest of a tick: four offsets taken off the clock before it is matched, whether passive scrolling is on, and when the clock was sampled. |
+| `tickOptions`   |                | `ElementTickOptions`                | `{}`     | The rest of a tick: four offsets taken off the clock before it is matched, whether passive scrolling is on, when the clock was sampled, and the rate the song is playing at. |
 | `theme`         | `theme`        | `string`                            | `""`     | A compiled stylesheet. See Theming.                                                                                                        |
 | `host`          |                | `Partial<LyricsRendererHost>`       | `{}`     | Overrides for what the renderer asks of its surroundings. Every member has a default. Writing it while connected rebuilds the view.        |
 | `renderer`      |                | `LyricsRenderer \| null` (get)      | `null`   | The renderer underneath, for the day the tag runs out. A different one after every reconnection.                                            |
@@ -255,6 +255,12 @@ lyric line sets `currentTime` back on it. So `currentTime` and `playing` become 
 either is dropped and the getter keeps reporting what the binding last read. Dropped rather than
 reported, because a consumer who bound a source and left their own frame loop running would otherwise
 be told about it sixty times a second. Unbind and the clock goes back to whoever asked for it.
+
+The rate is read off the media element too, and passed on as `tickOptions.playbackRate`, so a song at
+half or double speed animates at half or double speed rather than sweeping at 1x and being corrected
+on the next tick. A consumer driving the clock itself sets that option instead. Only the animations
+that follow the song are scaled: a line's exit, a word's fade and the scroll between lines keep the
+timing the theme asked for at every rate.
 
 A reading the media element has not refreshed yet is carried forward at the playback rate it was
 taken at, capped at 100ms of frame time. That cap is what covers a stall: the view runs at most 100ms

--- a/packages/core/src/element.selfcheck.ts
+++ b/packages/core/src/element.selfcheck.ts
@@ -1080,6 +1080,13 @@ assert.equal(
   "Given a frame that ran while the clock was running, When it is done, Then it asked for the next one"
 );
 
+// The guarantee every consumer written before the rate existed relies on.
+assert.deepEqual(
+  new Set(songAnimationRates(boundElement)),
+  new Set([1]),
+  "Given a song nobody said a rate for, When its animations are read, Then they run at 1x"
+);
+
 // -- A song played at something other than 1x --------------------------------------------
 
 boundMedia.playbackRate = DOUBLE_RATE;

--- a/packages/core/src/element.selfcheck.ts
+++ b/packages/core/src/element.selfcheck.ts
@@ -70,6 +70,7 @@ const ANCHOR_FRAME_MS = 1200;
 const CARRIED_MS = 50;
 const STALLED_MS = 500;
 const DOUBLE_RATE = 2;
+const HALF_RATE = 0.5;
 // What element.ts will carry a reading no further than.
 const MAX_CLOCK_CARRY_MS = 100;
 // MEDIA_ERR_NETWORK, which a truncated stream leaves behind mid-song without touching `paused`.
@@ -338,6 +339,14 @@ function hasRenderer(element: BraccatoLyricsElement): boolean {
 
 function selectedLines(element: BraccatoLyricsElement): boolean[] {
   return (element.renderer?.lines ?? []).map(line => line.isSelected);
+}
+
+// The rates the word animations are running at. A line also holds animations the interface owns
+// rather than the song, so this reads the parts, where the song's own are.
+function songAnimationRates(element: BraccatoLyricsElement): number[] {
+  return (element.renderer?.lines ?? []).flatMap(line =>
+    line.parts.flatMap(part => part.animations.map(animation => animation.playbackRate))
+  );
 }
 
 // What the build recorded on the container it made, which is where the flags a consumer hands to
@@ -1092,6 +1101,37 @@ assert.equal(
   boundElement.currentTime,
   LATE_PLAYBACK_TIME_S + (MAX_CLOCK_CARRY_MS * DOUBLE_RATE) / 1000,
   "Given a media clock that stopped without saying so, When frames keep running, Then the reading is carried only so far rather than running away from the song"
+);
+
+assert.deepEqual(
+  new Set(songAnimationRates(boundElement)),
+  new Set([DOUBLE_RATE]),
+  "Given a media element playing at a rate of its own, When the animations that follow the song are read, Then they run at that rate rather than at 1x"
+);
+
+boundMedia.playbackRate = 1;
+boundMedia.dispatch("ratechange");
+runFrames(bound.fakeWindow, ANCHOR_FRAME_MS + STALLED_MS);
+
+assert.deepEqual(
+  new Set(songAnimationRates(boundElement)),
+  new Set([1]),
+  "Given a rate that changed mid-song, When the animations already running are read, Then they moved onto the new rate rather than keeping the old one"
+);
+
+boundMedia.playbackRate = HALF_RATE;
+boundMedia.dispatch("ratechange");
+runFrames(bound.fakeWindow, ANCHOR_FRAME_MS + STALLED_MS);
+// A line the view has not built yet, so what it builds is where the rate has to be read again
+// rather than carried over from the animations the change already reached.
+boundMedia.currentTime = PLAYBACK_TIME_S;
+boundMedia.dispatch("seeked");
+runFrames(bound.fakeWindow, ANCHOR_FRAME_MS + STALLED_MS * 2);
+
+assert.deepEqual(
+  new Set(songAnimationRates(boundElement)),
+  new Set([HALF_RATE]),
+  "Given a rate settled before a line was reached, When that line's animations are built, Then they start on the song's rate rather than on 1x"
 );
 
 // -- A clock that stopped --------------------------------------------

--- a/packages/core/src/element.ts
+++ b/packages/core/src/element.ts
@@ -528,8 +528,15 @@ export class BraccatoLyricsElement extends HTMLElement {
     // A view with nothing built reports a missing container to the host on every tick, and a
     // consumer whose clock runs before the lyrics arrive is the ordinary case rather than a fault.
     if (renderer === null || renderer.container === null) return;
+    // The rate a bound media element is playing at is the element's to report, the same way the
+    // clock is, so it overrides what the consumer wrote for exactly as long as the binding lasts.
+    const boundRate = this.#media === null ? undefined : this.#media.playbackRate;
     // The play state last, so a consumer writing plain JavaScript cannot answer that question twice.
-    renderer.tick(this.#currentTimeS, { ...this.#tickOptions, isPlaying: this.#playing });
+    renderer.tick(this.#currentTimeS, {
+      ...this.#tickOptions,
+      ...(boundRate === undefined ? {} : { playbackRate: boundRate }),
+      isPlaying: this.#playing,
+    });
   }
 
   #upgradeProperty<

--- a/packages/core/src/engine.selfcheck.ts
+++ b/packages/core/src/engine.selfcheck.ts
@@ -595,6 +595,28 @@ const placeholderEngine = createAnimationEngineInstance(
 const placeholderMount = placeholderDocument.createElement("div");
 const passiveTickOptions: TickOptions = { ...newTickOptions(), passiveScrollEnabled: true };
 
+// -- The rate a tick was taken at --------------------------------------------
+
+assert.equal(
+  resolveTickOptions(newTickOptions()).playbackRate,
+  1,
+  "Given a tick that says nothing about rate, When it is resolved, Then the song is taken to be playing at 1x"
+);
+
+assert.deepEqual(
+  [-1, 0, Number.NaN, Number.POSITIVE_INFINITY].map(
+    rate => resolveTickOptions({ ...newTickOptions(), playbackRate: rate }).playbackRate
+  ),
+  [1, 1, 1, 1],
+  "Given a rate no song can be played at, When it is resolved, Then it reads as 1x rather than freezing everything the song owns"
+);
+
+assert.equal(
+  resolveTickOptions({ ...newTickOptions(), playbackRate: 0.25 }).playbackRate,
+  0.25,
+  "Given a rate a song can be played at, When it is resolved, Then it is passed through"
+);
+
 setLyrics(placeholderEngine, asElement<HTMLElement>(placeholderMount), UNSYNCED_LYRICS, {
   loaderVisible: false,
   noLyrics: false,

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -189,6 +189,7 @@ export interface AnimationEngineInstance extends AnimEngineViewState {
    * from a tick, so it has no options object to read.
    */
   passiveScrollEnabled: boolean;
+  playbackRate: number;
   passiveRAFId: number | null;
   pendingLyricsUpdateFrame: number | null;
   learnedAnimationTimingOffsetMs: number;
@@ -262,6 +263,7 @@ export function createAnimationEngineInstance(
     cachedCSSValues: new Map(),
     cachedAnimationSettings: null,
     passiveScrollEnabled: false,
+    playbackRate: 1,
     passiveRAFId: null,
     pendingLyricsUpdateFrame: null,
     learnedAnimationTimingOffsetMs: 0,
@@ -603,7 +605,27 @@ function trackLyricAnimationTiming(
     ...timing,
     appliedTimingOffsetMs: timing.appliedTimingOffsetMs ?? engine.learnedAnimationTimingOffsetMs,
   });
+  // Being tracked is what makes an animation the song's rather than the interface's, so it is also
+  // what decides which ones follow the song's rate.
+  animation.playbackRate = engine.playbackRate;
   return animation;
+}
+
+/**
+ * Puts the animations already running onto a new rate. Setting `playbackRate` keeps `currentTime`,
+ * so each one carries on from where the song left it rather than restarting.
+ */
+function applyPlaybackRateToRunningAnimations(engine: AnimationEngineInstance): void {
+  for (const line of engine.lines) {
+    for (const animation of line.animations) {
+      if (animationTimingTracks.has(animation)) animation.playbackRate = engine.playbackRate;
+    }
+    for (const part of line.parts) {
+      for (const animation of part.animations) {
+        if (animationTimingTracks.has(animation)) animation.playbackRate = engine.playbackRate;
+      }
+    }
+  }
 }
 
 function correctedAnimationTimeMs(targetTimeMs: number, appliedTimingOffsetMs: number, maxTimeMs?: number): number {
@@ -2310,7 +2332,14 @@ export function resolveTickOptions(options: TickOptions): ResolvedTickOptions {
     richsyncOffsetTrim: options.richsyncOffsetTrim ?? 0,
     lineOffsetTrim: options.lineOffsetTrim ?? 0,
     passiveScrollEnabled: options.passiveScrollEnabled ?? false,
+    playbackRate: resolvePlaybackRate(options.playbackRate),
   };
+}
+
+// A rate of zero or less would freeze every animation that follows the song, which is a second
+// answer to the question `isPlaying` already answers.
+function resolvePlaybackRate(rate: number | undefined): number {
+  return rate !== undefined && Number.isFinite(rate) && rate > 0 ? rate : 1;
 }
 
 /**
@@ -2323,6 +2352,11 @@ export function tickView(
 ): AnimationTickStatus {
   const { eventCreationTime, isPlaying, smoothScroll } = options;
   engine.passiveScrollEnabled = options.passiveScrollEnabled;
+
+  if (engine.playbackRate !== options.playbackRate) {
+    engine.playbackRate = options.playbackRate;
+    applyPlaybackRateToRunningAnimations(engine);
+  }
 
   const now = Date.now();
   if (currentTime === 0 && !isPlaying) {

--- a/packages/core/src/selfcheck/fakeDom.ts
+++ b/packages/core/src/selfcheck/fakeDom.ts
@@ -89,10 +89,11 @@ class FakeStyle {
 // animation, and a fixture whose subject is not scrolling switches scroll animation off in its
 // theme for the same reason. Covering any of that needs an animation that reports a real
 // `playState` and a `currentTime` that moves, which is a fake of a different size.
-class FakeAnimation {
+export class FakeAnimation {
   currentTime: number | null = null;
   readonly playState = "idle";
   cancelled = false;
+  playbackRate = 1;
 
   cancel(): void {
     this.cancelled = true;
@@ -112,6 +113,7 @@ export class FakeNode {
   readonly childNodes: FakeNode[] = [];
   readonly clickListeners: ClickListener[] = [];
   readonly dispatchedEvents: unknown[] = [];
+  readonly animations: FakeAnimation[] = [];
   parentNode: FakeNode | null = null;
   dir = "";
   id = "";
@@ -189,7 +191,9 @@ export class FakeNode {
   }
 
   animate(): FakeAnimation {
-    return new FakeAnimation();
+    const animation = new FakeAnimation();
+    this.animations.push(animation);
+    return animation;
   }
 
   get textContent(): string {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -42,6 +42,14 @@ export interface TickOptions {
    * false.
    */
   passiveScrollEnabled?: boolean;
+
+  /**
+   * How fast the song moves through its own timeline, as a multiple of real time. Defaults to 1, and
+   * zero or less reads as 1 because `isPlaying` is what says a song is stopped. Scales the animations
+   * that follow the song; a line's exit, a word's fade and the scroll between lines are the
+   * interface's own gestures and keep the timing the theme asked for at every rate.
+   */
+  playbackRate?: number;
 }
 
 /**


### PR DESCRIPTION
## Overview

Animations that follow the song were seeded from song time and then left to run against the wall clock, so at 0.25x a word's sweep finished four times too early and sat there until the next tick dragged it back. That snap-back is what reads as stutter. Measured before: 250ms of animation per 61ms of song. After: 162.5ms per 162.4ms.

Ticks can now carry `playbackRate`, and the animations tracked as the song's own run at it. The ones the interface owns, a line's exit, a word's fade, the scroll between lines, deliberately stay on the wall clock, since nobody wants autoscroll crawling at quarter speed. A bound media element fills the rate in itself; everyone else passes it. Defaults to 1, so a consumer that says nothing gets exactly what it got before.
