### PR TITLE
fix(core): take the room below the last line rather than ask for it

### DIFF
--- a/packages/core/src/engine.selfcheck.ts
+++ b/packages/core/src/engine.selfcheck.ts
@@ -11,12 +11,19 @@ import {
   getRenderedSyncType,
   hasRenderedLines,
   noteUserScroll,
+  relayout,
   resolveTickOptions,
   scheduleLyricPositionUpdate,
   tickView,
 } from "./engine";
-import { asDocument, asElement, collectTree, FakeDocument, type FakeNode } from "./selfcheck/fakeDom";
-import { asWindow, FakeMediaQueryList, FakeWindow, poisonAmbientGlobals } from "./selfcheck/fakeWindow";
+import { asDocument, asElement, asFakeNode, collectTree, FakeDocument, type FakeNode } from "./selfcheck/fakeDom";
+import {
+  asWindow,
+  FakeMediaQueryList,
+  FakeWindow,
+  installFakeDOMRect,
+  poisonAmbientGlobals,
+} from "./selfcheck/fakeWindow";
 import type { Lyric, LyricsRendererHost, TickOptions } from "./types";
 import { setLyrics } from "./view";
 
@@ -36,6 +43,8 @@ const ambientGlobals = poisonAmbientGlobals(
   name => `The renderer read the ambient global ${name} instead of the one its instance was handed`
 );
 
+installFakeDOMRect();
+
 // -- Measurements the host owns --------------------------------------------
 
 const VIEWPORT_HEIGHT_PX = 400;
@@ -45,11 +54,27 @@ const PLAYBACK_TIME_S = 0.2;
 // -- Fake host --------------------------------------------
 
 // The scroll container belongs to the host, not to the module, so it is not built from either
-// document. It answers only what the tick reads off it.
+// document. It answers only what the tick reads off it, and it clamps a `scrollTop` write the way a
+// browser does: silently, which is what a module aiming past the end of its content relies on.
 class FakeScrollElement {
-  scrollTop = 0;
+  private currentScrollTop = 0;
 
-  constructor(readonly viewportHeight: number) {}
+  constructor(
+    readonly viewportHeight: number,
+    readonly scrollHeight = viewportHeight * 100
+  ) {}
+
+  get clientHeight(): number {
+    return this.viewportHeight;
+  }
+
+  get scrollTop(): number {
+    return this.currentScrollTop;
+  }
+
+  set scrollTop(value: number) {
+    this.currentScrollTop = Math.max(0, Math.min(value, this.scrollHeight - this.clientHeight));
+  }
 
   getBoundingClientRect(): { height: number } {
     return { height: this.viewportHeight };
@@ -59,7 +84,11 @@ class FakeScrollElement {
 class FakeHost implements LyricsRendererHost {
   readonly resumeAffordanceCalls: boolean[] = [];
   readonly logs: unknown[][] = [];
-  readonly scrollElement = new FakeScrollElement(VIEWPORT_HEIGHT_PX);
+  readonly scrollElement: FakeScrollElement;
+
+  constructor(contentHeight?: number) {
+    this.scrollElement = new FakeScrollElement(VIEWPORT_HEIGHT_PX, contentHeight);
+  }
 
   isViewVisible(): boolean {
     return true;
@@ -642,6 +671,63 @@ assert.equal(
 );
 
 placeholderEngine.destroy();
+
+// -- The end of the song is somewhere the scroll can actually reach -----------------------------
+
+const OUTRO_LINE_HEIGHT_PX = 60;
+const OUTRO_LAST_LINE_POSITION_PX = 3000;
+const UNPADDED_CONTENT_HEIGHT_PX = OUTRO_LAST_LINE_POSITION_PX + OUTRO_LINE_HEIGHT_PX;
+
+const outroDocument = new FakeDocument();
+const outroWindow = new FakeWindow({ [ANIMATE_SCROLL_PROPERTY]: "0" });
+const outroHost = new FakeHost(UNPADDED_CONTENT_HEIGHT_PX);
+const outroMount = outroDocument.createElement("div");
+const outroEngine = createAnimationEngineInstance(asDocument(outroDocument), asWindow(outroWindow), outroHost);
+
+setLyrics(outroEngine, asElement<HTMLElement>(outroMount), LINE_SYNCED_LYRICS, {
+  loaderVisible: false,
+  noLyrics: false,
+});
+
+getRenderedLines(outroEngine).forEach((line, index, lines) => {
+  line.position = OUTRO_LAST_LINE_POSITION_PX - (lines.length - 1 - index) * OUTRO_LINE_HEIGHT_PX;
+  line.height = OUTRO_LINE_HEIGHT_PX;
+});
+
+const LAST_LINE_TIME_S = LINE_SYNCED_LYRICS[LINE_SYNCED_LYRICS.length - 1].startTimeMs / 1000;
+tickView(outroEngine, LAST_LINE_TIME_S, resolveTickOptions(newTickOptions()));
+
+// The positive control: a fixture too thin to reach the scroll maths would pass the next assertion
+// by never having scrolled at all.
+assert.ok(
+  outroHost.scrollElement.scrollTop > 0,
+  "Given the last line of a song, When the view ticks at its time, Then it scrolled towards that line at all"
+);
+
+assert.equal(
+  outroEngine.scrollPos,
+  outroHost.scrollElement.scrollTop,
+  "Given a container a theme left too short to centre the last line, When the view scrolls to it, Then it aims where the scroll can go rather than past the end of the content"
+);
+
+// -- The room below the last line is taken, not asked for --------------------------------------
+
+relayout(outroEngine, false);
+
+const outroContainer = asFakeNode(outroEngine.lyricsContainer!);
+
+assert.ok(
+  Number.parseFloat(outroContainer.style.getPropertyValue("padding-bottom")) > 0,
+  "Given a view sizing the room below its last line, When the container is read, Then it carries that room where no theme rule can outrank it"
+);
+
+assert.equal(
+  outroContainer.style.getPropertyValue("padding-bottom"),
+  outroDocument.documentElement.style.getPropertyValue("--blyrics-padding-bottom"),
+  "Given a view sizing the room below its last line, When the published property is read, Then it still names the length the container took"
+);
+
+outroEngine.destroy();
 
 // -- Destroying one view releases only what it held --------------------------------------------
 

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -2440,6 +2440,7 @@ export function tickView(
     }
     const tabRendererHeight = engine.cachedTabRendererHeight ?? tabRenderer.getBoundingClientRect().height;
     let scrollTop = tabRenderer.scrollTop;
+    const maxScrollTop = Math.max(0, tabRenderer.scrollHeight - tabRenderer.clientHeight);
     if (animationConfig.enabled.scroll) {
       updateVisibleLyricWillChange(
         engine,
@@ -2653,8 +2654,9 @@ export function tickView(
       // Make sure top of last active lyric is visible.
       scrollPos = Math.min(scrollPos, lastActiveLyric.position);
 
-      // Make sure we're not trying to scroll to negative values
-      scrollPos = Math.max(0, scrollPos);
+      // Past either end the browser clamps the write and reports nothing, leaving the view aiming
+      // at a position it never reached and re-aiming once per remaining line.
+      scrollPos = clamp(scrollPos, 0, maxScrollTop);
 
       if (ENABLE_DEBUG_RENDER.getBooleanValue()) {
         let transform = engine.window.getComputedStyle(lyricsElement).transform;
@@ -2920,6 +2922,9 @@ function applyScrollPadding(engine: AnimationEngineInstance): void {
 
   engine.document.documentElement.style.setProperty("--blyrics-padding-top", top + "px");
   engine.document.documentElement.style.setProperty("--blyrics-padding-bottom", bottom + "px");
+  // Inline, because a theme's own `.blyrics-container { padding }` is appended after the package's
+  // stylesheet at the same weight and would otherwise take this room away.
+  lyricsElement.style.setProperty("padding-bottom", bottom + "px");
 }
 
 /**

--- a/packages/core/src/renderer.selfcheck.ts
+++ b/packages/core/src/renderer.selfcheck.ts
@@ -71,6 +71,8 @@ const ANIMATION_TIMING_LOG_SETTING = "blyrics-debug-animation-timing";
 const REBUILD_THEME = "/* blyrics-disable-richsync = true; */";
 const RESPELT_REBUILD_THEME = "/*blyrics-disable-richsync=true;*/";
 const NEUTRAL_THEME = "/* blyrics-target-scroll-pos-ratio = 0.5; */";
+// What the target scroll position falls back to once a theme stops naming one.
+const DEFAULT_TARGET_SCROLL_RATIO = 0.37;
 
 const MAX_SWALLOWED_SCROLLS = 8;
 
@@ -1568,6 +1570,13 @@ assert.deepEqual(
 themedRenderer.setLyrics(SYNCED_LYRICS);
 themedRenderer.tick(PLAYBACK_TIME_S, { isPlaying: true });
 
+// Content taller than the viewport, so that the target scroll position is what the room below the
+// last line is sized by rather than the viewport's own floor.
+const themedContainer = asFakeNode(themedRenderer.container!);
+themedContainer.scrollHeight = SCROLL_CONTAINER_HEIGHT_PX * 4;
+themedRenderer.relayout();
+const roomUnderNeutralTarget = themedContainer.style.getPropertyValue("padding-bottom");
+
 const propertyReadsBeforeThemeChange = themed.fakeWindow.propertyReads.length;
 themedRenderer.tick(PLAYBACK_TIME_S, { isPlaying: true });
 
@@ -1587,6 +1596,18 @@ assert.deepEqual(
   appliedThemeSheets(),
   [REBUILD_THEME],
   "Given a view that already carries a theme, When a second one is applied, Then it replaces the first rather than stacking another sheet on top of it"
+);
+
+assert.equal(
+  themedContainer.style.getPropertyValue("padding-bottom"),
+  SCROLL_CONTAINER_HEIGHT_PX * (1 - DEFAULT_TARGET_SCROLL_RATIO) + "px",
+  "Given a theme that moves the target scroll position, When it is applied, Then the room below the last line is sized again for the target it asks for"
+);
+
+assert.notEqual(
+  themedContainer.style.getPropertyValue("padding-bottom"),
+  roomUnderNeutralTarget,
+  "Given a theme that moves the target scroll position, When it is applied, Then that room is not the length the target before it asked for"
 );
 
 themedRenderer.tick(PLAYBACK_TIME_S, { isPlaying: true });

--- a/packages/core/src/renderer.selfcheck.ts
+++ b/packages/core/src/renderer.selfcheck.ts
@@ -189,6 +189,9 @@ function newViewFixture(styleValues: Record<string, string> = SCROLL_ANIMATION_O
   const mount = fakeDocument.createElement("div");
 
   scrollContainer.offsetHeight = SCROLL_CONTAINER_HEIGHT_PX;
+  scrollContainer.clientHeight = SCROLL_CONTAINER_HEIGHT_PX;
+  // A song's worth of content under it, so the scroll ceiling is never what a check here is reading.
+  scrollContainer.scrollHeight = SCROLL_CONTAINER_HEIGHT_PX * 100;
   scrollContainer.appendChild(mount);
   fakeWindow.overflowByElement.set(scrollContainer, "auto");
 

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -308,6 +308,10 @@ export function createLyricsRenderer(rendererOptions: LyricsRendererOptions): Ly
       // Everything the engine resolved off the document was resolved against the theme that just
       // went away.
       clearEngineStyleCaches(engine);
+      // The target scroll position is one of the settings a theme carries, and the scroll padding is
+      // sized against it, so a theme that moves the target moves the layout even when no rule in it
+      // does.
+      measure();
       return needsLyricRebuild;
     },
     tick(currentTimeS, options) {

--- a/packages/core/src/selfcheck/fakeDom.ts
+++ b/packages/core/src/selfcheck/fakeDom.ts
@@ -315,6 +315,7 @@ export class FakeDocument {
   // Where a stylesheet goes. Built directly rather than through the factories, so it stays out of
   // the factory call counts below.
   readonly head = new FakeNode(this, "element", "head");
+  readonly documentElement = new FakeNode(this, "element", "html");
   // What a document scrolls by when nothing between the mount and the root does. Left unset rather
   // than built here, so a self-check that never asks about it does not pay for an element in its
   // factory call counts.


### PR DESCRIPTION
## Overview

The padding that lets the last line reach its scroll position was published as a custom property and spent by the package stylesheet, so any theme setting `padding` on the container quietly took it back. Four of the themes we ship do. With the room gone the view kept aiming past the end of the content, and since a clamped `scrollTop` write reports nothing, it re-aimed at the same unreachable spot once per remaining line. Now the container carries that padding inline where a theme can't outrank it, and the scroll target is capped at what the scroller can actually reach so a shortfall settles instead of thrashing.
