### PR TITLE
feat(core): let a theme redraw the shapes the instrumental wave morphs between

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -179,6 +179,13 @@ The ones a theme reaches for first. `variables.css` declares the rest.
 `line-height`. Every word is given the glow, so a theme that wants it to mean something selects on
 `data-long-word`, which the module sets on any part held past `blyrics-long-word-threshold`.
 
+The instrumental ripple is the one place a property carries geometry rather than a value.
+`--blyrics-instrumental-wave-path-high` and `--blyrics-instrumental-wave-path-low` are the two shapes
+it morphs between, each a `path()`, and a theme redrawing them is how the wave changes amplitude or
+frequency. Both must use the same commands in the same order with the same number of arguments: a
+browser only interpolates two paths smoothly when their command sequences match, and a mismatched
+pair snaps at the halfway point instead of flowing.
+
 ### Class names
 
 These are published API rather than implementation. Renaming one costs a migration rather than a

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -26,6 +26,7 @@ import {
   USER_SCROLLING_CLASS,
 } from "./constants";
 import type { LineData, PartData } from "./inject";
+import { INSTRUMENTAL_WAVE_PATH_HIGH, INSTRUMENTAL_WAVE_PATH_LOW } from "./instrumental";
 import { registerThemeSetting } from "./themeSettings";
 import type { LyricsRendererHost, LyricSyncType, ResolvedTickOptions, TickOptions } from "./types";
 import { clamp, getRelativeLayoutBounds, positiveModulo, roundedMs, toMs } from "./util";
@@ -464,8 +465,8 @@ const WORD_HIGHLIGHT_SELECTOR = ".blyrics-word-highlight";
 const INSTRUMENTAL_FILL_SELECTOR = ".blyrics--instrumental-fill";
 const INSTRUMENTAL_WAVE_CLIP_SELECTOR = ".blyrics--wave-clip";
 const INSTRUMENTAL_WAVE_PATH_SELECTOR = ".blyrics--wave-path";
-const INSTRUMENTAL_WAVE_PATH_HIGH = 'path("M -4 3 Q 1 2 5 3 Q 10 4 14 3 Q 18 2 22 3 Q 26 4 30 3 L 30 4 L -4 4 Z")';
-const INSTRUMENTAL_WAVE_PATH_LOW = 'path("M -4 3 Q 1 4 5 3 Q 10 2 14 3 Q 18 4 22 3 Q 26 2 30 3 L 30 4 L -4 4 Z")';
+const INSTRUMENTAL_WAVE_PATH_HIGH_FALLBACK = `path("${INSTRUMENTAL_WAVE_PATH_HIGH}")`;
+const INSTRUMENTAL_WAVE_PATH_LOW_FALLBACK = `path("${INSTRUMENTAL_WAVE_PATH_LOW}")`;
 type LineScrollSide = "above" | "active" | "below";
 type LineScrollKeyframe = "start" | "end";
 interface LineScrollItem {
@@ -553,6 +554,8 @@ interface AnimationConfig {
     waveFrom: string;
     waveTo: string;
     waveEasing: string;
+    wavePathHigh: string;
+    wavePathLow: string;
     waveOscillationDurationMs: number;
     waveOscillationEasing: string;
   };
@@ -1378,9 +1381,9 @@ function startInstrumentalAnimations(
       lineData,
       INSTRUMENTAL_WAVE_PATH_SELECTOR,
       [
-        { d: INSTRUMENTAL_WAVE_PATH_HIGH },
-        { d: INSTRUMENTAL_WAVE_PATH_LOW, offset: 0.5 },
-        { d: INSTRUMENTAL_WAVE_PATH_HIGH },
+        { d: config.instrumental.wavePathHigh },
+        { d: config.instrumental.wavePathLow, offset: 0.5 },
+        { d: config.instrumental.wavePathHigh },
       ],
       {
         duration: config.instrumental.waveOscillationDurationMs,
@@ -1646,6 +1649,18 @@ function readAnimationConfig(engine: AnimationEngineInstance, lyricsElement: HTM
       waveFrom: getCSSValue(engine, lyricsElement, "--blyrics-instrumental-wave-transform-from", "scaleY(1.2)"),
       waveTo: getCSSValue(engine, lyricsElement, "--blyrics-instrumental-wave-transform-to", "scaleY(0.0001)"),
       waveEasing: getCSSValue(engine, lyricsElement, "--blyrics-instrumental-wave-easing", "ease-in"),
+      wavePathHigh: getCSSValue(
+        engine,
+        lyricsElement,
+        "--blyrics-instrumental-wave-path-high",
+        INSTRUMENTAL_WAVE_PATH_HIGH_FALLBACK
+      ),
+      wavePathLow: getCSSValue(
+        engine,
+        lyricsElement,
+        "--blyrics-instrumental-wave-path-low",
+        INSTRUMENTAL_WAVE_PATH_LOW_FALLBACK
+      ),
       waveOscillationDurationMs: getCSSDurationWithFallback(
         engine,
         lyricsElement,

--- a/packages/core/src/instrumental.selfcheck.ts
+++ b/packages/core/src/instrumental.selfcheck.ts
@@ -1,0 +1,54 @@
+import { strict as assert } from "node:assert";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { INSTRUMENTAL_WAVE_PATH_HIGH, INSTRUMENTAL_WAVE_PATH_LOW } from "./instrumental";
+
+const VARIABLES_CSS = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), "styles/variables.css"), "utf8");
+
+function readDeclaredPath(property: string): string {
+  const match = new RegExp(`${property}:\\s*path\\("([^"]*)"\\)\\s*;`).exec(VARIABLES_CSS);
+  assert.ok(match, `Given styles/variables.css, When ${property} is read, Then it declares one path() value`);
+  return match[1];
+}
+
+const declaredHigh = readDeclaredPath("--blyrics-instrumental-wave-path-high");
+const declaredLow = readDeclaredPath("--blyrics-instrumental-wave-path-low");
+
+assert.equal(
+  declaredHigh,
+  INSTRUMENTAL_WAVE_PATH_HIGH,
+  "Given the high wave path lives in both the module and its stylesheet, When the two are compared, Then a theme that overrides nothing sees the shape the module would have drawn anyway"
+);
+
+assert.equal(
+  declaredLow,
+  INSTRUMENTAL_WAVE_PATH_LOW,
+  "Given the low wave path lives in both the module and its stylesheet, When the two are compared, Then a theme that overrides nothing sees the shape the module would have drawn anyway"
+);
+
+function pathSignature(path: string): string {
+  const segments = path.match(/[A-Za-z][^A-Za-z]*/g);
+  assert.ok(segments, `Given the path "${path}", When it is split, Then it holds at least one command`);
+  return segments
+    .map(segment => {
+      const command = segment[0];
+      const argumentCount = segment.slice(1).match(/-?\d*\.?\d+/g)?.length ?? 0;
+      return `${command}${argumentCount}`;
+    })
+    .join(" ");
+}
+
+assert.equal(
+  pathSignature("M -4 3 Q 1 2 5 3 Z"),
+  "M2 Q4 Z0",
+  "Given a path of known shape, When its signature is taken, Then each command carries the count of numbers that followed it"
+);
+
+assert.equal(
+  pathSignature(INSTRUMENTAL_WAVE_PATH_LOW),
+  pathSignature(INSTRUMENTAL_WAVE_PATH_HIGH),
+  "Given the two shapes the ripple morphs between, When their signatures are compared, Then a browser interpolates them smoothly rather than snapping at the halfway point"
+);
+
+console.log(`Instrumental wave self-check passed over ${pathSignature(INSTRUMENTAL_WAVE_PATH_HIGH)}`);

--- a/packages/core/src/instrumental.ts
+++ b/packages/core/src/instrumental.ts
@@ -1,3 +1,6 @@
+export const INSTRUMENTAL_WAVE_PATH_HIGH = "M -4 3 Q 1 2 5 3 Q 10 4 14 3 Q 18 2 22 3 Q 26 4 30 3 L 30 4 L -4 4 Z";
+export const INSTRUMENTAL_WAVE_PATH_LOW = "M -4 3 Q 1 4 5 3 Q 10 2 14 3 Q 18 4 22 3 Q 26 2 30 3 L 30 4 L -4 4 Z";
+
 /**
  * Creates an HTML element representing an instrumental break in the lyrics.
  *
@@ -72,9 +75,7 @@ export function createInstrumentalElement(
   // This only contains the surface water. It closes at y=4.
   const wavePath = doc.createElementNS(svgNS, "path");
   wavePath.classList.add("blyrics--wave-path");
-
-  // Initial draw (matches the 0% keyframe below)
-  wavePath.setAttribute("d", "M -4 3 Q 1 2 5 3 Q 10 4 14 3 Q 18 2 22 3 Q 26 4 30 3 L 30 4 L -4 4 Z");
+  wavePath.setAttribute("d", INSTRUMENTAL_WAVE_PATH_HIGH);
   clipPath.appendChild(wavePath);
 
   defs.appendChild(clipPath);

--- a/packages/core/src/styles/instrumental.css
+++ b/packages/core/src/styles/instrumental.css
@@ -69,6 +69,8 @@
 
 	/* Prepare the WAAPI flatten transition. */
 	transform: scaleY(1.2);
+
+	d: var(--blyrics-instrumental-wave-path-high);
 }
 
 /* Trigger the Flattening */
@@ -89,15 +91,4 @@
 	transition-property: transform;
 	transition-timing-function: ease-out;
 	transition-delay: 0s;
-}
-
-/* Update Keyframes for the "Split" shape */
-/* These paths must close at 'L 30 4 L -4 4' to match the static rect overlap */
-@keyframes blyrics-wave {
-	0%, 100% {
-		d: path("M -4 3 Q 1 2 5 3 Q 10 4 14 3 Q 18 2 22 3 Q 26 4 30 3 L 30 4 L -4 4 Z");
-	}
-	50% {
-		d: path("M -4 3 Q 1 4 5 3 Q 10 2 14 3 Q 18 4 22 3 Q 26 2 30 3 L 30 4 L -4 4 Z");
-	}
 }

--- a/packages/core/src/styles/variables.css
+++ b/packages/core/src/styles/variables.css
@@ -117,6 +117,8 @@
 	--blyrics-instrumental-wave-transform-from: scaleY(1.2);
 	--blyrics-instrumental-wave-transform-to: scaleY(0.0001);
 	--blyrics-instrumental-wave-easing: ease-in;
+	--blyrics-instrumental-wave-path-high: path("M -4 3 Q 1 2 5 3 Q 10 4 14 3 Q 18 2 22 3 Q 26 4 30 3 L 30 4 L -4 4 Z");
+	--blyrics-instrumental-wave-path-low: path("M -4 3 Q 1 4 5 3 Q 10 2 14 3 Q 18 4 22 3 Q 26 2 30 3 L 30 4 L -4 4 Z");
 	--blyrics-instrumental-wave-oscillation-duration: 1.25s;
 	--blyrics-instrumental-wave-oscillation-easing: ease-in-out;
 


### PR DESCRIPTION
Made the two paths the instrumental ripple morphs between into properties (`--blyrics-instrumental-wave-path-high` and `-low`) so a theme can change the wave's shape without forking.
