### PR TITLE
build: add package watch tooling and refresh demo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test-data/
 .env
 # Deployment settings are environment specific and not tracked.
 DEPLOY.md
+.idea

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/ShadcnHelperSettings.xml
+++ b/.idea/ShadcnHelperSettings.xml
@@ -1,0 +1,3491 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="com.ilscipio.shadcn.settings.ShadcnSettingsState">
+    <registryConfigs>
+      <RegistryConfigState>
+        <option name="id" value="official" />
+        <option name="name" value="Official shadcn/ui" />
+        <option name="namespace" value="@shadcn" />
+        <option name="baseUrl" value="https://ui.shadcn.com/r" />
+        <option name="type" value="official" />
+        <option name="builtin" value="true" />
+        <option name="description" value="The official shadcn/ui component registry" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="21st-dev" />
+        <option name="name" value="21st.dev" />
+        <option name="namespace" value="@21st" />
+        <option name="baseUrl" value="https://21st.dev/r" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="builtin" value="true" />
+        <option name="description" value="Open-source community components from 21st.dev" />
+        <option name="homepage" value="https://21st.dev" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-1st-pouf" />
+        <option name="name" value="1st-pouf" />
+        <option name="namespace" value="@1st-pouf" />
+        <option name="baseUrl" value="https://1st-pouf.worksonmy.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Puffy, pastel claymorphism components and app blocks for React, built with Tailwind CSS v4 and Radix UI." />
+        <option name="homepage" value="https://1st-pouf.worksonmy.dev" />
+        <option name="urlTemplate" value="https://1st-pouf.worksonmy.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-23rd" />
+        <option name="name" value="23rd" />
+        <option name="namespace" value="@23rd" />
+        <option name="baseUrl" value="https://23rd.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Opinionated components for shippers." />
+        <option name="homepage" value="https://23rd.dev" />
+        <option name="urlTemplate" value="https://23rd.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-7ovr" />
+        <option name="name" value="7ovr" />
+        <option name="namespace" value="@7ovr" />
+        <option name="baseUrl" value="https://7ovr.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Free, production-ready UI blocks for marketing pages and application dashboards, built on Base UI and installable with the shadcn CLI." />
+        <option name="homepage" value="https://7ovr.com" />
+        <option name="urlTemplate" value="https://7ovr.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-8bitcn" />
+        <option name="name" value="8bitcn" />
+        <option name="namespace" value="@8bitcn" />
+        <option name="baseUrl" value="https://www.8bitcn.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A set of 8-bit styled retro components. Works with your favorite frameworks. Open Source. Open Code." />
+        <option name="homepage" value="https://www.8bitcn.com" />
+        <option name="urlTemplate" value="https://www.8bitcn.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-8starlabs-ui" />
+        <option name="name" value="8starlabs-ui" />
+        <option name="namespace" value="@8starlabs-ui" />
+        <option name="baseUrl" value="https://ui.8starlabs.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A set of beautifully designed components designed for developers who want niche, high-utility UI elements that you won't find in standard libraries." />
+        <option name="homepage" value="https://ui.8starlabs.com" />
+        <option name="urlTemplate" value="https://ui.8starlabs.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-abstract" />
+        <option name="name" value="Abstract" />
+        <option name="namespace" value="@abstract" />
+        <option name="baseUrl" value="https://build.abs.xyz/r" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of React components for the most common crypto patterns" />
+        <option name="homepage" value="https://build.abs.xyz" />
+        <option name="urlTemplate" value="https://build.abs.xyz/r/{name}/json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-abui" />
+        <option name="name" value="Abui" />
+        <option name="namespace" value="@abui" />
+        <option name="baseUrl" value="https://abui.io/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A shadcn-compatible registry of reusable components, blocks, and utilities conforming to Vercel's components.build specification" />
+        <option name="homepage" value="https://abui.io" />
+        <option name="urlTemplate" value="https://abui.io/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-aceternity" />
+        <option name="name" value="Aceternity" />
+        <option name="namespace" value="@aceternity" />
+        <option name="baseUrl" value="https://ui.aceternity.com/registry" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A modern component library built with Tailwind CSS and Motion for React, Aceternity UI contains unique and interactive components that can make your landing pages look 100x better." />
+        <option name="homepage" value="https://ui.aceternity.com" />
+        <option name="urlTemplate" value="https://ui.aceternity.com/registry/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-aevr" />
+        <option name="name" value="Aevr" />
+        <option name="namespace" value="@aevr" />
+        <option name="baseUrl" value="https://ui.aevr.online/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A small collection of focused, production‑ready components and primitives for React/Next.js projects—built on shadcn/ui and complementary libraries." />
+        <option name="homepage" value="https://ui.aevr.online" />
+        <option name="urlTemplate" value="https://ui.aevr.online/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-agentcn" />
+        <option name="name" value="Agentcn" />
+        <option name="namespace" value="@agentcn" />
+        <option name="baseUrl" value="https://agentcn.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Production-ready agents, made simple. Ready to use, customizable AI agent recipes. Built on Eve and Flue." />
+        <option name="homepage" value="https://agentcn.vercel.app" />
+        <option name="urlTemplate" value="https://agentcn.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-agents-ui" />
+        <option name="name" value="Agents-ui" />
+        <option name="namespace" value="@agents-ui" />
+        <option name="baseUrl" value="https://livekit.com/ui/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="This is a shadcn/ui component registry that distributes copy-paste React components for building LiveKit AI Agent interfaces." />
+        <option name="homepage" value="https://livekit.com/ui" />
+        <option name="urlTemplate" value="https://livekit.com/ui/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-ai-blocks" />
+        <option name="name" value="Ai-blocks" />
+        <option name="namespace" value="@ai-blocks" />
+        <option name="baseUrl" value="https://webllm.org/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="AI components for the web. No server. No API keys. Built on WebLLM." />
+        <option name="homepage" value="https://webllm.org/blocks" />
+        <option name="urlTemplate" value="https://webllm.org/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-ai-elements" />
+        <option name="name" value="Ai-elements" />
+        <option name="namespace" value="@ai-elements" />
+        <option name="baseUrl" value="https://ai-sdk.dev/elements/api/registry" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Pre-built components like conversations, messages and more to help you build AI-native applications faster." />
+        <option name="homepage" value="https://ai-sdk.dev/elements" />
+        <option name="urlTemplate" value="https://ai-sdk.dev/elements/api/registry/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-aicanvas" />
+        <option name="name" value="Aicanvas" />
+        <option name="namespace" value="@aicanvas" />
+        <option name="baseUrl" value="https://aicanvas.me/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Animated React components with AI reproduction prompts, alongside full design systems and templates. Install via CLI or aicanvas MCP, compatible with Claude Code, Codex, and Cursor." />
+        <option name="homepage" value="https://aicanvas.me" />
+        <option name="urlTemplate" value="https://aicanvas.me/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-algolia" />
+        <option name="name" value="Algolia" />
+        <option name="namespace" value="@algolia" />
+        <option name="baseUrl" value="https://sitesearch.algolia.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Enterprises and developers use Algolia's AI search infrastructure to understand users and show them what they're looking for." />
+        <option name="homepage" value="https://sitesearch.algolia.com" />
+        <option name="urlTemplate" value="https://sitesearch.algolia.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-aliimam" />
+        <option name="name" value="Aliimam" />
+        <option name="namespace" value="@aliimam" />
+        <option name="baseUrl" value="https://aliimam.in/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="I create digital experiences that connect and inspire. I build apps, websites, brands, and products end-to-end." />
+        <option name="homepage" value="https://aliimam.in" />
+        <option name="urlTemplate" value="https://aliimam.in/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-amicro" />
+        <option name="name" value="Amicro" />
+        <option name="namespace" value="@amicro" />
+        <option name="baseUrl" value="https://amicro.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Open-source React micro-interactions and UI component registry powered by Motion." />
+        <option name="homepage" value="https://amicro.vercel.app" />
+        <option name="urlTemplate" value="https://amicro.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-amplo" />
+        <option name="name" value="Amplo" />
+        <option name="namespace" value="@amplo" />
+        <option name="baseUrl" value="https://amplo.ale.design/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="OKLCH-native, Display-P3-aware composable fill picker with WCAG/APCA contrast metrics, gamut detection, and full keyboard accessibility." />
+        <option name="homepage" value="https://amplo.ale.design" />
+        <option name="urlTemplate" value="https://amplo.ale.design/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-animate-ui" />
+        <option name="name" value="Animate-ui" />
+        <option name="namespace" value="@animate-ui" />
+        <option name="baseUrl" value="https://animate-ui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A fully animated, open-source React component distribution. Browse a list of animated primitives, components and icons you can install and use in your projects." />
+        <option name="homepage" value="https://animate-ui.com" />
+        <option name="urlTemplate" value="https://animate-ui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-animbits" />
+        <option name="name" value="Animbits" />
+        <option name="namespace" value="@animbits" />
+        <option name="baseUrl" value="https://animbits.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="AnimBits is a collection animated UI components for React that use Framer Motion. The components provided include buttons, cards, text, icons, lists, loaders, and page transitions, animation hooks all of which have general-purpose effects that are not flashy and easy on the eyes, making them easy to use." />
+        <option name="homepage" value="https://animbits.dev" />
+        <option name="urlTemplate" value="https://animbits.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-approvals-ui" />
+        <option name="name" value="Approvals-ui" />
+        <option name="namespace" value="@approvals-ui" />
+        <option name="baseUrl" value="https://approvals-ui.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Approval workflow components for React Flow: quorum gates, amount thresholds, a policy lint (segregation of duties, single approver on high value), and plain-language editing behind a human review gate." />
+        <option name="homepage" value="https://approvals-ui.vercel.app" />
+        <option name="urlTemplate" value="https://approvals-ui.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-arc" />
+        <option name="name" value="Arc" />
+        <option name="namespace" value="@arc" />
+        <option name="baseUrl" value="https://witharc.co/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Animated, accessible UI components built with React and Tailwind CSS." />
+        <option name="homepage" value="https://witharc.co/components" />
+        <option name="urlTemplate" value="https://witharc.co/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-asanshay" />
+        <option name="name" value="Asanshay" />
+        <option name="namespace" value="@asanshay" />
+        <option name="baseUrl" value="https://ds.asanshay.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Clean, beautiful, and simple UI primitives and AI elements." />
+        <option name="homepage" value="https://ds.asanshay.com" />
+        <option name="urlTemplate" value="https://ds.asanshay.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-assistant-ui" />
+        <option name="name" value="Assistant-ui" />
+        <option name="namespace" value="@assistant-ui" />
+        <option name="baseUrl" value="https://r.assistant-ui.com" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Radix-style React primitives for AI chat with adapters for AI SDK, LangGraph, Mastra, and custom backends." />
+        <option name="homepage" value="https://www.assistant-ui.com" />
+        <option name="urlTemplate" value="https://r.assistant-ui.com/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-auth0" />
+        <option name="name" value="Auth0" />
+        <option name="namespace" value="@auth0" />
+        <option name="baseUrl" value="https://ui.auth0.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Official Auth0 Universal Components for Web. Accelerate development with pre-built, embeddable UI for enterprise SSO, MFA, and organization management" />
+        <option name="homepage" value="https://auth0.com" />
+        <option name="urlTemplate" value="https://ui.auth0.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-baraile-loader" />
+        <option name="name" value="Baraile-loader" />
+        <option name="namespace" value="@baraile-loader" />
+        <option name="baseUrl" value="https://shadcn-braille-loader.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A simple braille-inspired loader components for shadcn/ui." />
+        <option name="homepage" value="https://shadcn-braille-loader.vercel.app" />
+        <option name="urlTemplate" value="https://shadcn-braille-loader.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-basecn" />
+        <option name="name" value="Basecn" />
+        <option name="namespace" value="@basecn" />
+        <option name="baseUrl" value="https://basecn.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautifully crafted shadcn/ui components powered by Base UI" />
+        <option name="homepage" value="https://basecn.dev" />
+        <option name="urlTemplate" value="https://basecn.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-baselayer" />
+        <option name="name" value="Baselayer" />
+        <option name="namespace" value="@baselayer" />
+        <option name="baseUrl" value="https://www.baselayer.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of components built on React Aria, Tailwind CSS, and tailwind-variants." />
+        <option name="homepage" value="https://www.baselayer.dev" />
+        <option name="urlTemplate" value="https://www.baselayer.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-benday" />
+        <option name="name" value="Benday" />
+        <option name="namespace" value="@benday" />
+        <option name="baseUrl" value="https://benday.kacemmathlouthi.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Turn any logo into an animated Ben-Day dot field: a thinking indicator for AI and agent interfaces, baked from your own mark." />
+        <option name="homepage" value="https://benday.kacemmathlouthi.dev" />
+        <option name="urlTemplate" value="https://benday.kacemmathlouthi.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-beste-ui" />
+        <option name="name" value="Beste-ui" />
+        <option name="namespace" value="@beste-ui" />
+        <option name="baseUrl" value="https://ui.beste.co/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Production-ready UI blocks for landing pages, dashboards, and web apps." />
+        <option name="homepage" value="https://ui.beste.co" />
+        <option name="urlTemplate" value="https://ui.beste.co/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-better-auth-ui" />
+        <option name="name" value="Better-auth-ui" />
+        <option name="namespace" value="@better-auth-ui" />
+        <option name="baseUrl" value="https://better-auth-ui.com/r/{style}" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Drop-in authentication components for Better Auth applications." />
+        <option name="homepage" value="https://better-auth-ui.com" />
+        <option name="urlTemplate" value="https://better-auth-ui.com/r/{style}/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-better-upload" />
+        <option name="name" value="Better-upload" />
+        <option name="namespace" value="@better-upload" />
+        <option name="baseUrl" value="https://better-upload.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Simple and easy file uploads for React. Upload directly to any S3-compatible service with minimal setup." />
+        <option name="homepage" value="https://better-upload.com" />
+        <option name="urlTemplate" value="https://better-upload.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-beui" />
+        <option name="name" value="Beui" />
+        <option name="namespace" value="@beui" />
+        <option name="baseUrl" value="https://beui.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Bespoke motion components for React. Copy-paste components with shadcn-compatible installs, Tailwind CSS v4, and Motion." />
+        <option name="homepage" value="https://beui.dev" />
+        <option name="urlTemplate" value="https://beui.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-billingsdk" />
+        <option name="name" value="Billingsdk" />
+        <option name="namespace" value="@billingsdk" />
+        <option name="baseUrl" value="https://billingsdk.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="BillingSDK is an open-source React and Next.js component library for SaaS billing and payments. It offers ready-to-use, customizable components for subscriptions, invoices, usage-based pricing and billing - fully compatible with Dodo Payments and Stripe." />
+        <option name="homepage" value="https://billingsdk.com" />
+        <option name="urlTemplate" value="https://billingsdk.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-bklit" />
+        <option name="name" value="Bklit" />
+        <option name="namespace" value="@bklit" />
+        <option name="baseUrl" value="https://ui.bklit.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Open-source composable chart components for React — line, area, bar, pie, radar, maps, and more. Built with Visx, Motion, and shadcn/ui." />
+        <option name="homepage" value="https://ui.bklit.com" />
+        <option name="urlTemplate" value="https://ui.bklit.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-blocks-so" />
+        <option name="name" value="Blocks-so" />
+        <option name="namespace" value="@blocks-so" />
+        <option name="baseUrl" value="https://blocks.so/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A set of clean, modern application building blocks for you in your applications. Free and Open Source" />
+        <option name="homepage" value="https://blocks.so" />
+        <option name="urlTemplate" value="https://blocks.so/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-blockforge" />
+        <option name="name" value="Blockforge" />
+        <option name="namespace" value="@blockforge" />
+        <option name="baseUrl" value="https://blockforge.terravidhal.me/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="170+ production-grade shadcn/ui blocks, forged to ship. Full source in TypeScript + Tailwind CSS, plus a page builder and starter pages. Copy, paste, ship." />
+        <option name="homepage" value="https://blockforge.terravidhal.me" />
+        <option name="urlTemplate" value="https://blockforge.terravidhal.me/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-blockus" />
+        <option name="name" value="Blockus" />
+        <option name="namespace" value="@blockus" />
+        <option name="baseUrl" value="https://blockus.lndevui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Production-ready React blocks built on shadcn/ui and Tailwind — drop them in, swap the copy, ship the page. Heroes, pricing and footer sections crafted by hand." />
+        <option name="homepage" value="https://blockus.lndevui.com" />
+        <option name="urlTemplate" value="https://blockus.lndevui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-blode" />
+        <option name="name" value="Blode" />
+        <option name="namespace" value="@blode" />
+        <option name="baseUrl" value="https://blode.co/ui/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="An open-source registry of accessible React components built on Base UI and Tailwind CSS v4. Install with one command, then own the source." />
+        <option name="homepage" value="https://blode.co/ui" />
+        <option name="urlTemplate" value="https://blode.co/ui/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-boldkit" />
+        <option name="name" value="Boldkit" />
+        <option name="namespace" value="@boldkit" />
+        <option name="baseUrl" value="https://boldkit.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Neubrutalism component library with 43 components, 42 SVG shapes, thick borders, and hard shadows. Supports React, Vue, and Nuxt. Built on shadcn/ui." />
+        <option name="homepage" value="https://boldkit.dev" />
+        <option name="urlTemplate" value="https://boldkit.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-brainless" />
+        <option name="name" value="Brainless" />
+        <option name="namespace" value="@brainless" />
+        <option name="baseUrl" value="https://brainless.swerdlow.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Claude Code, Codex, and Grok interfaces as shadcn components — accessible React terminal-agent UI for docs, demos, and product surfaces." />
+        <option name="homepage" value="https://brainless.swerdlow.dev" />
+        <option name="urlTemplate" value="https://brainless.swerdlow.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-brut-ui" />
+        <option name="name" value="Brut-ui" />
+        <option name="namespace" value="@brut-ui" />
+        <option name="baseUrl" value="https://www.brut-ui.site/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Production-minded neo-brutalist shadcn components with three configurable flavours, strengths, and radius modes." />
+        <option name="homepage" value="https://www.brut-ui.site" />
+        <option name="urlTemplate" value="https://www.brut-ui.site/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-bundui" />
+        <option name="name" value="Bundui" />
+        <option name="namespace" value="@bundui" />
+        <option name="baseUrl" value="https://bundui.io/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of 150+ handcrafted UI components built with Tailwind CSS and shadcn/ui, covering marketing, e-commerce, dashboards, real estate, and more." />
+        <option name="homepage" value="https://bundui.io" />
+        <option name="urlTemplate" value="https://bundui.io/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-canvas-ui" />
+        <option name="name" value="Canvas-ui" />
+        <option name="namespace" value="@canvas-ui" />
+        <option name="baseUrl" value="https://canvasui.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Creative html-in-canvas components. React, Vue, Svelte, TS." />
+        <option name="homepage" value="https://canvasui.dev/" />
+        <option name="urlTemplate" value="https://canvasui.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-cardcn" />
+        <option name="name" value="Cardcn" />
+        <option name="namespace" value="@cardcn" />
+        <option name="baseUrl" value="https://cardcn.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A set of beautifully-designed shadcn card components" />
+        <option name="homepage" value="https://cardcn.dev" />
+        <option name="urlTemplate" value="https://cardcn.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-chamaac" />
+        <option name="name" value="Chamaac" />
+        <option name="namespace" value="@chamaac" />
+        <option name="baseUrl" value="https://chamaac.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of beautiful, animated components to elevate your web projects instantly." />
+        <option name="homepage" value="https://chamaac.com" />
+        <option name="urlTemplate" value="https://chamaac.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-channel3" />
+        <option name="name" value="Channel3" />
+        <option name="namespace" value="@channel3" />
+        <option name="baseUrl" value="https://ui.trychannel3.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Open-source React components for building shopping experiences on the Channel3 product API: search, filters, product detail, offer comparison, and price history." />
+        <option name="homepage" value="https://trychannel3.com/developers/ui" />
+        <option name="urlTemplate" value="https://ui.trychannel3.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-clerk" />
+        <option name="name" value="Clerk" />
+        <option name="namespace" value="@clerk" />
+        <option name="baseUrl" value="https://clerk.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="The easiest way to add authentication and user management to your application. Purpose-built for React, Next.js, Remix, and The Modern Web." />
+        <option name="homepage" value="https://clerk.com/docs/guides/development/shadcn-cli" />
+        <option name="urlTemplate" value="https://clerk.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-cnippet" />
+        <option name="name" value="Cnippet" />
+        <option name="namespace" value="@cnippet" />
+        <option name="baseUrl" value="https://ui.cnippet.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Cnippet UI is a production-ready, curated set of accessible and composable React components—built with Base UI and Tailwind CSS. Copy, paste, and ship stunning interfaces faster." />
+        <option name="homepage" value="https://ui.cnippet.dev/" />
+        <option name="urlTemplate" value="https://ui.cnippet.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-cognicatch" />
+        <option name="name" value="Cognicatch" />
+        <option name="namespace" value="@cognicatch" />
+        <option name="baseUrl" value="https://cognicatch.dev/registry" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Adaptive Error Boundaries and graceful fallback UIs (Banners, Modals, Toasts)." />
+        <option name="homepage" value="https://cognicatch.dev" />
+        <option name="urlTemplate" value="https://cognicatch.dev/registry/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-commercn" />
+        <option name="name" value="Commercn" />
+        <option name="namespace" value="@commercn" />
+        <option name="baseUrl" value="https://commercn.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Shadcn UI Blocks for Ecommerce websites" />
+        <option name="homepage" value="https://commercn.com" />
+        <option name="urlTemplate" value="https://commercn.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-componentry" />
+        <option name="name" value="Componentry" />
+        <option name="namespace" value="@componentry" />
+        <option name="baseUrl" value="https://componentry.fun/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautiful, interactive React + Tailwind components for modern product UIs." />
+        <option name="homepage" value="https://componentry.fun" />
+        <option name="urlTemplate" value="https://componentry.fun/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-contentbit" />
+        <option name="name" value="Contentbit" />
+        <option name="namespace" value="@contentbit" />
+        <option name="baseUrl" value="https://contentbit.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="React components that render Content Blocks: plain Markdown with schema-validated directive blocks. Built for content written by humans, CMSes, and LLMs." />
+        <option name="homepage" value="https://contentbit.dev" />
+        <option name="urlTemplate" value="https://contentbit.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-corr" />
+        <option name="name" value="Corr" />
+        <option name="namespace" value="@corr" />
+        <option name="baseUrl" value="https://ui.corr.sh/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of shadcn-based React components, charts, animated components, and blocks built over time." />
+        <option name="homepage" value="https://ui.corr.sh" />
+        <option name="urlTemplate" value="https://ui.corr.sh/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-coss" />
+        <option name="name" value="Coss" />
+        <option name="namespace" value="@coss" />
+        <option name="baseUrl" value="https://coss.com/ui/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A new, modern UI component library built on top of Base UI. Built for developers and AI." />
+        <option name="homepage" value="https://coss.com/ui" />
+        <option name="urlTemplate" value="https://coss.com/ui/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-creative-tim" />
+        <option name="name" value="Creative-tim" />
+        <option name="namespace" value="@creative-tim" />
+        <option name="baseUrl" value="https://www.creative-tim.com/ui/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of open-source UI components, blocks and AI Agents. Integrate them in v0, Lovable, Claude or in your application." />
+        <option name="homepage" value="https://www.creative-tim.com/ui" />
+        <option name="urlTemplate" value="https://www.creative-tim.com/ui/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-cubby-ui" />
+        <option name="name" value="Cubby-ui" />
+        <option name="namespace" value="@cubby-ui" />
+        <option name="baseUrl" value="https://www.cubby-ui.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="An opinionated component library with curated styling and simplified patterns for common use cases. Built on Base UI and Tailwind CSS 4." />
+        <option name="homepage" value="https://www.cubby-ui.dev" />
+        <option name="urlTemplate" value="https://www.cubby-ui.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-cult-ui" />
+        <option name="name" value="Cult-ui" />
+        <option name="namespace" value="@cult-ui" />
+        <option name="baseUrl" value="https://cult-ui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Cult UI is a rare, curated set of shadcn-compatible, headless and composable components—tastefully animated with Framer Motion." />
+        <option name="homepage" value="https://www.cult-ui.com" />
+        <option name="urlTemplate" value="https://cult-ui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-darx" />
+        <option name="name" value="Darx" />
+        <option name="namespace" value="@darx" />
+        <option name="baseUrl" value="https://darshitdev.in/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Magic 3D Tabs component featuring mouse-interactive 3D rotation, floating particles background effect, and smooth spring animations." />
+        <option name="homepage" value="https://darshitdev.in/arts" />
+        <option name="urlTemplate" value="https://darshitdev.in/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-delego" />
+        <option name="name" value="Delego" />
+        <option name="namespace" value="@delego" />
+        <option name="baseUrl" value="https://raw.githubusercontent.com/Delego-Dev/registry/main/public/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Design-system registry for Delego — intent-bound action authorization for AI agents. Theme (OKLCH) plus signature components: decision pill, signed receipt, status badge, field." />
+        <option name="homepage" value="https://github.com/Delego-Dev/registry" />
+        <option name="urlTemplate" value="https://raw.githubusercontent.com/Delego-Dev/registry/main/public/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-delta" />
+        <option name="name" value="Delta" />
+        <option name="namespace" value="@delta" />
+        <option name="baseUrl" value="https://deltacomponents.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A shadcn registry for AI and media-rich interfaces — streaming LLM chat, zoomable images, swipeable card decks, interactive maps, plus dashboard and landing-page blocks." />
+        <option name="homepage" value="https://deltacomponents.dev" />
+        <option name="urlTemplate" value="https://deltacomponents.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-devl" />
+        <option name="name" value="Devl" />
+        <option name="namespace" value="@devl" />
+        <option name="baseUrl" value="https://devl.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Hand-crafted layouts and UI primitives for shipping fast." />
+        <option name="homepage" value="https://devl.dev" />
+        <option name="urlTemplate" value="https://devl.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-diceui" />
+        <option name="name" value="Diceui" />
+        <option name="namespace" value="@diceui" />
+        <option name="baseUrl" value="https://diceui.com/r/{style}" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Accessible shadcn/ui components built with React, TypeScript, and Tailwind CSS. Copy-paste ready, and customizable." />
+        <option name="homepage" value="https://www.diceui.com/" />
+        <option name="urlTemplate" value="https://diceui.com/r/{style}/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-diklein" />
+        <option name="name" value="Diklein" />
+        <option name="namespace" value="@diklein" />
+        <option name="baseUrl" value="https://diklein.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A growing collection of design-forward React components by Dave Klein, extracted from the components powering diklein.com." />
+        <option name="homepage" value="https://diklein.com/components" />
+        <option name="urlTemplate" value="https://diklein.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-dominik-ui" />
+        <option name="name" value="Dominik-ui" />
+        <option name="namespace" value="@dominik-ui" />
+        <option name="baseUrl" value="https://dominikkoch.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Opinionated components and tools for building modern AI interfaces." />
+        <option name="homepage" value="https://dominikkoch.dev/ui" />
+        <option name="urlTemplate" value="https://dominikkoch.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-doras-ui" />
+        <option name="name" value="Doras-ui" />
+        <option name="namespace" value="@doras-ui" />
+        <option name="baseUrl" value="https://ui.doras.to/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of beautiful, reusable component blocks built with React" />
+        <option name="homepage" value="https://ui.doras.to/" />
+        <option name="urlTemplate" value="https://ui.doras.to/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-dotmatrix" />
+        <option name="name" value="Dotmatrix" />
+        <option name="namespace" value="@dotmatrix" />
+        <option name="baseUrl" value="https://dotmatrix.zzzzshawn.cloud/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Production-ready dot-matrix loading components for React, featuring square, circular, and triangle animations with polished motion." />
+        <option name="homepage" value="https://dotmatrix.zzzzshawn.cloud" />
+        <option name="urlTemplate" value="https://dotmatrix.zzzzshawn.cloud/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-dsikeres1" />
+        <option name="name" value="Dsikeres1" />
+        <option name="namespace" value="@dsikeres1" />
+        <option name="baseUrl" value="https://dsikeres1.github.io/react-date-range-picker/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A headless, composable date &amp; date range picker for React. 5 picker types, 15 locales, dark mode, accessible. Zero dependencies." />
+        <option name="homepage" value="https://dsikeres1.github.io/react-date-range-picker/" />
+        <option name="urlTemplate" value="https://dsikeres1.github.io/react-date-range-picker/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-efferd" />
+        <option name="name" value="Efferd" />
+        <option name="namespace" value="@efferd" />
+        <option name="baseUrl" value="https://efferd.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of beautifully crafted Shadcn/UI blocks, designed to help developers build modern websites with ease." />
+        <option name="homepage" value="https://efferd.com/" />
+        <option name="urlTemplate" value="https://efferd.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-einui" />
+        <option name="name" value="Einui" />
+        <option name="namespace" value="@einui" />
+        <option name="baseUrl" value="https://ui.eindev.ir/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautiful, responsive Shadcn components with frosted glass morphism. Built for modern web applications with full dark mode support." />
+        <option name="homepage" value="https://ui.eindev.ir" />
+        <option name="urlTemplate" value="https://ui.eindev.ir/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-eldoraui" />
+        <option name="name" value="Eldoraui" />
+        <option name="namespace" value="@eldoraui" />
+        <option name="baseUrl" value="https://eldoraui.site/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="An open-source, modern UI component library for React, built with TypeScript, Tailwind CSS, and Framer Motion. Eldora UI offers beautifully crafted, reusable components designed for performance and elegance." />
+        <option name="homepage" value="https://eldoraui.site" />
+        <option name="urlTemplate" value="https://eldoraui.site/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-elements" />
+        <option name="name" value="Elements" />
+        <option name="namespace" value="@elements" />
+        <option name="baseUrl" value="https://www.tryelements.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Full-stack shadcn/ui components that go beyond UI. Add auth, monetization, uploads, and AI to your app in seconds." />
+        <option name="homepage" value="https://www.tryelements.dev" />
+        <option name="urlTemplate" value="https://www.tryelements.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-elevenlabs-ui" />
+        <option name="name" value="Elevenlabs-ui" />
+        <option name="namespace" value="@elevenlabs-ui" />
+        <option name="baseUrl" value="https://ui.elevenlabs.io/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of Open Source agent and audio components that you can customize and extend." />
+        <option name="homepage" value="https://ui.elevenlabs.io" />
+        <option name="urlTemplate" value="https://ui.elevenlabs.io/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-emerald-ui" />
+        <option name="name" value="Emerald-ui" />
+        <option name="namespace" value="@emerald-ui" />
+        <option name="baseUrl" value="https://emerald-ui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Emerald UI - collection of components built with Motion, GSAP, Tailwind CSS and shadcn/ui." />
+        <option name="homepage" value="https://emerald-ui.com" />
+        <option name="urlTemplate" value="https://emerald-ui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-ericts" />
+        <option name="name" value="Ericts" />
+        <option name="namespace" value="@ericts" />
+        <option name="baseUrl" value="https://ui.ericts.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Motion-focused shadcn-compatible components, hooks, and blocks for polished React interfaces." />
+        <option name="homepage" value="https://ui.ericts.com" />
+        <option name="urlTemplate" value="https://ui.ericts.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-evex" />
+        <option name="name" value="Evex" />
+        <option name="namespace" value="@evex" />
+        <option name="baseUrl" value="https://evex.sh/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Installable AI agent recipes for Eve apps, including PR review, data analysis, and workflow automation agents." />
+        <option name="homepage" value="https://evex.sh" />
+        <option name="urlTemplate" value="https://evex.sh/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-evilbuttons" />
+        <option name="name" value="Evilbuttons" />
+        <option name="namespace" value="@evilbuttons" />
+        <option name="baseUrl" value="https://evilbuttons.radiumcoders.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A shadcn/ui registry featuring a collection of animated buttons built with Motion. Each component is designed to add punchy, interactive feedback to your UI with minimal setup." />
+        <option name="homepage" value="https://evilbuttons.radiumcoders.com/docs" />
+        <option name="urlTemplate" value="https://evilbuttons.radiumcoders.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-evilcharts" />
+        <option name="name" value="Evilcharts" />
+        <option name="namespace" value="@evilcharts" />
+        <option name="baseUrl" value="https://evilcharts.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="EvilCharts is an open-source chart UI website built with shadcn and Recharts, beautifully designed and handcrafted." />
+        <option name="homepage" value="https://evilcharts.com" />
+        <option name="urlTemplate" value="https://evilcharts.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-exabase" />
+        <option name="name" value="Exabase" />
+        <option name="namespace" value="@exabase" />
+        <option name="baseUrl" value="https://exawizards.com/exabase/design/registry" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of UI components based on the exaBase Design System, built with React and Tailwind CSS." />
+        <option name="homepage" value="https://exawizards.com/exabase/design/" />
+        <option name="urlTemplate" value="https://exawizards.com/exabase/design/registry/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-extend" />
+        <option name="name" value="Extend" />
+        <option name="namespace" value="@extend" />
+        <option name="baseUrl" value="https://ui.extend.ai/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of UI components for building document agents and human-in-the-loop review workflows." />
+        <option name="homepage" value="https://ui.extend.ai" />
+        <option name="urlTemplate" value="https://ui.extend.ai/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-fab-ui" />
+        <option name="name" value="Fab-ui" />
+        <option name="namespace" value="@fab-ui" />
+        <option name="baseUrl" value="https://fab-ui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of beautifully designed UI components for building modern web applications." />
+        <option name="homepage" value="https://fab-ui.com" />
+        <option name="urlTemplate" value="https://fab-ui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-flagcn" />
+        <option name="name" value="Flagcn" />
+        <option name="namespace" value="@flagcn" />
+        <option name="baseUrl" value="https://flagcn.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Accessible, source-owned flag components for shadcn/ui with 306 flags in SVG, PNG, WebP, and JPEG plus 4:3, 1:1, and original ratios." />
+        <option name="homepage" value="https://flagcn.dev" />
+        <option name="urlTemplate" value="https://flagcn.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-flightcn" />
+        <option name="name" value="Flightcn" />
+        <option name="namespace" value="@flightcn" />
+        <option name="baseUrl" value="https://flightcn.yencheng.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Flight routes on interactive maps with great-circle arcs, airport markers, multi-leg journeys, and optional animation, built for mapcn." />
+        <option name="homepage" value="https://flightcn.yencheng.dev" />
+        <option name="urlTemplate" value="https://flightcn.yencheng.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-flowui" />
+        <option name="name" value="Flowui" />
+        <option name="namespace" value="@flowui" />
+        <option name="baseUrl" value="https://flowui-registry.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Everyday use react components to make the development flow easier for the devs." />
+        <option name="homepage" value="https://flowui-registry.vercel.app" />
+        <option name="urlTemplate" value="https://flowui-registry.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-flowkit-ui" />
+        <option name="name" value="Flowkit-ui" />
+        <option name="namespace" value="@flowkit-ui" />
+        <option name="baseUrl" value="https://flowkit-ui.vzkiss.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Opinionated, accessible components on Base UI and shadcn-style primitives — starting with a Creatable Combobox." />
+        <option name="homepage" value="https://flowkit-ui.vzkiss.com" />
+        <option name="urlTemplate" value="https://flowkit-ui.vzkiss.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-fluid" />
+        <option name="name" value="Fluid" />
+        <option name="namespace" value="@fluid" />
+        <option name="baseUrl" value="https://www.fluidfunctionalism.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Fluid components used exclusively in service of functional clarity. Proximity hover, spring animations, font-weight transitions, and animated focus rings." />
+        <option name="homepage" value="https://www.fluidfunctionalism.com" />
+        <option name="urlTemplate" value="https://www.fluidfunctionalism.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-flx" />
+        <option name="name" value="Flx" />
+        <option name="namespace" value="@flx" />
+        <option name="baseUrl" value="https://ui.flexnative.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of customizable UI blocks with interactive live previews" />
+        <option name="homepage" value="https://ui.flexnative.com" />
+        <option name="urlTemplate" value="https://ui.flexnative.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-fonttrio" />
+        <option name="name" value="Fonttrio" />
+        <option name="namespace" value="@fonttrio" />
+        <option name="baseUrl" value="https://www.fonttrio.xyz/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Curated font pairing registry for shadcn. Three fonts. One command. Install perfectly configured typography (heading + body + mono) with shadcn add. Includes editorial-grade type scales, CSS variables, and a live preview site." />
+        <option name="homepage" value="https://www.fonttrio.xyz" />
+        <option name="urlTemplate" value="https://www.fonttrio.xyz/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-forgeui" />
+        <option name="name" value="Forgeui" />
+        <option name="namespace" value="@forgeui" />
+        <option name="baseUrl" value="https://forgeui.in/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautifully designed components that you can copy and paste into your apps. Accessible. Customizable. Open Source." />
+        <option name="homepage" value="https://forgeui.in/" />
+        <option name="urlTemplate" value="https://forgeui.in/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-formcn" />
+        <option name="name" value="Formcn" />
+        <option name="namespace" value="@formcn" />
+        <option name="baseUrl" value="https://formcn.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Build production-ready forms with a few clicks using shadcn components and modern tools." />
+        <option name="homepage" value="https://formcn.dev" />
+        <option name="urlTemplate" value="https://formcn.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-framecn" />
+        <option name="name" value="Framecn" />
+        <option name="namespace" value="@framecn" />
+        <option name="baseUrl" value="https://framecn.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautiful videos, made simple. Ready to use, customizable video components for React." />
+        <option name="homepage" value="https://framecn.vercel.app" />
+        <option name="urlTemplate" value="https://framecn.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-gaia" />
+        <option name="name" value="Gaia" />
+        <option name="namespace" value="@gaia" />
+        <option name="baseUrl" value="https://ui.heygaia.io/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Production-ready UI components designed for building beautiful AI assistants and conversational interfaces, from the team behind GAIA." />
+        <option name="homepage" value="https://ui.heygaia.io" />
+        <option name="urlTemplate" value="https://ui.heygaia.io/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-gamekitui" />
+        <option name="name" value="Gamekitui" />
+        <option name="namespace" value="@gamekitui" />
+        <option name="baseUrl" value="https://gamekitui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Drop-in, themeable browser games for shadcn — Snake, 2048, Minesweeper, and more. Each is a single self-contained file with zero dependencies." />
+        <option name="homepage" value="https://gamekitui.com" />
+        <option name="urlTemplate" value="https://gamekitui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-gamifykit" />
+        <option name="name" value="Gamifykit" />
+        <option name="namespace" value="@gamifykit" />
+        <option name="baseUrl" value="https://gamifykit.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of fully composable components that extend shadcn/ui with a focus on common gamification UI patterns." />
+        <option name="homepage" value="https://gamifykit.com" />
+        <option name="urlTemplate" value="https://gamifykit.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-gammaui" />
+        <option name="name" value="Gammaui" />
+        <option name="namespace" value="@gammaui" />
+        <option name="baseUrl" value="https://www.gammaui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautifully designed landing page components built with React &amp; Tailwind CSS &amp; Motion." />
+        <option name="homepage" value="https://www.gammaui.com" />
+        <option name="urlTemplate" value="https://www.gammaui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-gc-solid" />
+        <option name="name" value="Gc-solid" />
+        <option name="namespace" value="@gc-solid" />
+        <option name="baseUrl" value="https://binnodon.github.io/gc-solid-ui/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="SolidJS port of shadcn-ui components built with Kobalte primitives. 57+ components with full TypeScript support and Vega theme." />
+        <option name="homepage" value="https://binnodon.github.io/gc-solid-ui" />
+        <option name="urlTemplate" value="https://binnodon.github.io/gc-solid-ui/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-glass-ui" />
+        <option name="name" value="Glass-ui" />
+        <option name="namespace" value="@glass-ui" />
+        <option name="baseUrl" value="https://glass-ui.crenspire.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A shadcn-ui compatible registry distributing 40+ glassmorphic React/TypeScript components with Apple-inspired design. Components include enhanced visual effects (glow, shimmer, ripple), theme support, and customizable glassmorphism styling." />
+        <option name="homepage" value="https://glass-ui.crenspire.com" />
+        <option name="urlTemplate" value="https://glass-ui.crenspire.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-glasscn" />
+        <option name="name" value="Glasscn" />
+        <option name="namespace" value="@glasscn" />
+        <option name="baseUrl" value="https://glasscn-components.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A shadcn-compatible registry of glassmorphism components inspired by Apple" />
+        <option name="homepage" value="https://glasscn-components.vercel.app/" />
+        <option name="urlTemplate" value="https://glasscn-components.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-gooseui" />
+        <option name="name" value="Gooseui" />
+        <option name="namespace" value="@gooseui" />
+        <option name="baseUrl" value="https://gooseui.pro/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Open source component library with animated components, beautiful effects, and custom toast notifications. Built with Radix UI and Tailwind CSS." />
+        <option name="homepage" value="https://gooseui.pro" />
+        <option name="urlTemplate" value="https://gooseui.pro/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-gpt-vis" />
+        <option name="name" value="Gpt-vis" />
+        <option name="namespace" value="@gpt-vis" />
+        <option name="baseUrl" value="https://gpt-vis.antv.vision/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="AI-native visualization components for LLM projects. Render 26 chart types from vis syntax strings or config objects." />
+        <option name="homepage" value="https://gpt-vis.antv.vision" />
+        <option name="urlTemplate" value="https://gpt-vis.antv.vision/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-gymnopedies" />
+        <option name="name" value="Gymnopedies" />
+        <option name="namespace" value="@gymnopedies" />
+        <option name="baseUrl" value="https://gymnopedies.shoota.work/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A dark, serif, glow-leaning shadcn registry of read-only components for blogs, essays, and long-form reading experiences — inspired by the quiet, candlelit cabaret of Erik Satie's Gymnopédies." />
+        <option name="homepage" value="https://gymnopedies.shoota.work" />
+        <option name="urlTemplate" value="https://gymnopedies.shoota.work/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-grootstudio" />
+        <option name="name" value="Grootstudio" />
+        <option name="namespace" value="@grootstudio" />
+        <option name="baseUrl" value="https://grootstudio.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A premium, open source component registry for SEO-friendly, high-performance React applications" />
+        <option name="homepage" value="https://grootstudio.vercel.app" />
+        <option name="urlTemplate" value="https://grootstudio.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-ha-components" />
+        <option name="name" value="Ha-components" />
+        <option name="namespace" value="@ha-components" />
+        <option name="baseUrl" value="https://hacomponents.keshuac.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of customisable components to build Home Assistant dashboards." />
+        <option name="homepage" value="https://hacomponents.keshuac.com" />
+        <option name="urlTemplate" value="https://hacomponents.keshuac.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-headcodecms" />
+        <option name="name" value="Headcodecms" />
+        <option name="namespace" value="@headcodecms" />
+        <option name="baseUrl" value="https://headcodecms.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A Minimalistic Web CMS for Next.js, optimized for Cache Components." />
+        <option name="homepage" value="https://headcodecms.com" />
+        <option name="urlTemplate" value="https://headcodecms.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-heroicons-animated" />
+        <option name="name" value="Heroicons-animated" />
+        <option name="namespace" value="@heroicons-animated" />
+        <option name="baseUrl" value="https://www.heroicons-animated.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="An open-source collection of 316 beautifully animated heroicons for your projects." />
+        <option name="homepage" value="https://www.heroicons-animated.com/" />
+        <option name="urlTemplate" value="https://www.heroicons-animated.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-hextaui" />
+        <option name="name" value="Hextaui" />
+        <option name="namespace" value="@hextaui" />
+        <option name="baseUrl" value="https://hextaui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Ready-to-use foundation components/blocks built on top of shadcn/ui." />
+        <option name="homepage" value="https://hextaui.com" />
+        <option name="urlTemplate" value="https://hextaui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-hexui" />
+        <option name="name" value="Hexui" />
+        <option name="namespace" value="@hexui" />
+        <option name="baseUrl" value="https://hexui.sh/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A shadcn/ui registry of high-quality React blocks and templates." />
+        <option name="homepage" value="https://hexui.sh" />
+        <option name="urlTemplate" value="https://hexui.sh/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-hirael" />
+        <option name="name" value="Hirael" />
+        <option name="namespace" value="@hirael" />
+        <option name="baseUrl" value="https://hirael.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="The components shadcn/ui doesn't ship. A collection of high-utility React components built on top of shadcn/ui." />
+        <option name="homepage" value="https://hirael.com" />
+        <option name="urlTemplate" value="https://hirael.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-honestui" />
+        <option name="name" value="Honestui" />
+        <option name="namespace" value="@honestui" />
+        <option name="baseUrl" value="https://www.honestui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="React UI components, animated interactions, shaders, and charts distributed as editable source." />
+        <option name="homepage" value="https://www.honestui.com" />
+        <option name="urlTemplate" value="https://www.honestui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-hugeicons-animated" />
+        <option name="name" value="Hugeicons-animated" />
+        <option name="namespace" value="@hugeicons-animated" />
+        <option name="baseUrl" value="https://hugeicons-animated.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="An open-source collection of animated Hugeicons for React." />
+        <option name="homepage" value="https://hugeicons-animated.com" />
+        <option name="urlTemplate" value="https://hugeicons-animated.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-iconiq" />
+        <option name="name" value="Iconiq" />
+        <option name="namespace" value="@iconiq" />
+        <option name="baseUrl" value="https://iconiqui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Iconiq is a collection of icons designed for web applications. It is a modern, clean, and minimalistic icon set that is perfect for web applications." />
+        <option name="homepage" value="https://iconiqui.com" />
+        <option name="urlTemplate" value="https://iconiqui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-icons-animated" />
+        <option name="name" value="Icons-animated" />
+        <option name="namespace" value="@icons-animated" />
+        <option name="baseUrl" value="https://icons.lndev.me/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="An open-source library of meticulously animated icons (Tabler, Phosphor, and more) for your projects, inspired by lucide-animated.com" />
+        <option name="homepage" value="https://icons.lndev.me" />
+        <option name="urlTemplate" value="https://icons.lndev.me/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-ilinxa" />
+        <option name="name" value="Ilinxa" />
+        <option name="namespace" value="@ilinxa" />
+        <option name="baseUrl" value="https://ui.ilinxa.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="High-level composed components for shadcn/ui — kanban, gantt, calendar, media editors, story viewers, flow canvas, forms, and more, each with optional demo fixtures." />
+        <option name="homepage" value="https://ui.ilinxa.com" />
+        <option name="urlTemplate" value="https://ui.ilinxa.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-indiacn" />
+        <option name="name" value="Indiacn" />
+        <option name="namespace" value="@indiacn" />
+        <option name="baseUrl" value="https://indiacn.in/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="UX4G 2.0 design system for India — many accessible React components and an 8-color theme preset for native apps." />
+        <option name="homepage" value="https://indiacn.in" />
+        <option name="urlTemplate" value="https://indiacn.in/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-inferencesh" />
+        <option name="name" value="Inferencesh" />
+        <option name="namespace" value="@inferencesh" />
+        <option name="baseUrl" value="https://ui.inference.sh/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="batteries-included agent components by inference.sh. chat interfaces with streaming, tool invocation rendering, syntax-highlighted code blocks, markdown renderer, and more." />
+        <option name="homepage" value="https://ui.inference.sh" />
+        <option name="urlTemplate" value="https://ui.inference.sh/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-initium" />
+        <option name="name" value="Initium" />
+        <option name="namespace" value="@initium" />
+        <option name="baseUrl" value="https://app.initium.sh/r/styles/{style}" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Conversion-focused marketing blocks and landing page sections for shadcn/ui, with a visual style editor, agent skills, and the first block of every category free to install." />
+        <option name="homepage" value="https://initium.sh" />
+        <option name="urlTemplate" value="https://app.initium.sh/r/styles/{style}/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-intentui" />
+        <option name="name" value="Intentui" />
+        <option name="namespace" value="@intentui" />
+        <option name="baseUrl" value="https://intentui.com/r" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Accessible React component library to copy, customize, and own your UI." />
+        <option name="homepage" value="https://intentui.com" />
+        <option name="urlTemplate" value="https://intentui.com/r/{name}" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-interior" />
+        <option name="name" value="Interior" />
+        <option name="namespace" value="@interior" />
+        <option name="baseUrl" value="https://www.interior.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Copy-paste React micro-interactions: a headless hook plus a styled example in one self-contained file, with motion as the only dependency." />
+        <option name="homepage" value="https://www.interior.dev" />
+        <option name="urlTemplate" value="https://www.interior.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-jalco" />
+        <option name="name" value="Jalco" />
+        <option name="namespace" value="@jalco" />
+        <option name="baseUrl" value="https://ui.justinlevine.me/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A curated collection of GitHub-integrated, documentation, and developer-facing components. Self-contained, zero-dependency, and production-ready." />
+        <option name="homepage" value="https://ui.justinlevine.me" />
+        <option name="urlTemplate" value="https://ui.justinlevine.me/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-jolyui" />
+        <option name="name" value="Jolyui" />
+        <option name="namespace" value="@jolyui" />
+        <option name="baseUrl" value="https://www.jolyui.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="JolyUI is a modern React component library built with TypeScript and Tailwind CSS." />
+        <option name="homepage" value="https://www.jolyui.dev" />
+        <option name="urlTemplate" value="https://www.jolyui.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-joyco" />
+        <option name="name" value="Joyco" />
+        <option name="namespace" value="@joyco" />
+        <option name="baseUrl" value="https://registry.joyco.studio/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Components including MobileMenu, ScrollArea with gradients, Chat UI, HLSVideoPlayer, and Marquee." />
+        <option name="homepage" value="https://registry.joyco.studio" />
+        <option name="urlTemplate" value="https://registry.joyco.studio/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-kanpeki" />
+        <option name="name" value="Kanpeki" />
+        <option name="namespace" value="@kanpeki" />
+        <option name="baseUrl" value="https://kanpeki.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A set of perfect-designed components built on top of React Aria and Motion." />
+        <option name="homepage" value="https://kanpeki.vercel.app" />
+        <option name="urlTemplate" value="https://kanpeki.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-kapwa" />
+        <option name="name" value="Kapwa" />
+        <option name="namespace" value="@kapwa" />
+        <option name="baseUrl" value="https://kapwa-two.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Cleanly designed components purposely built for open-source government portals." />
+        <option name="homepage" value="https://kapwa-two.vercel.app" />
+        <option name="urlTemplate" value="https://kapwa-two.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-kibo-ui" />
+        <option name="name" value="Kibo-ui" />
+        <option name="namespace" value="@kibo-ui" />
+        <option name="baseUrl" value="https://www.kibo-ui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Kibo UI is a custom registry of composable, accessible and open source components designed for use with shadcn/ui." />
+        <option name="homepage" value="https://www.kibo-ui.com/" />
+        <option name="urlTemplate" value="https://www.kibo-ui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-kinetic" />
+        <option name="name" value="Kinetic" />
+        <option name="namespace" value="@kinetic" />
+        <option name="baseUrl" value="https://kinetic.itsjay.in/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A Figma-like scrub number field for shadcn/ui (base-nova). Digit animation by Calligraph." />
+        <option name="homepage" value="https://kinetic.itsjay.in" />
+        <option name="urlTemplate" value="https://kinetic.itsjay.in/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-kokonutui" />
+        <option name="name" value="Kokonutui" />
+        <option name="namespace" value="@kokonutui" />
+        <option name="baseUrl" value="https://kokonutui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Collection of stunning components built with Tailwind CSS, shadcn/ui and Motion to use on your websites." />
+        <option name="homepage" value="https://kokonutui.com" />
+        <option name="urlTemplate" value="https://kokonutui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-launchui" />
+        <option name="name" value="Launchui" />
+        <option name="namespace" value="@launchui" />
+        <option name="baseUrl" value="https://www.launchuicomponents.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Carefully crafted landing page components and templates built with React, Shadcn/ui and Tailwind." />
+        <option name="homepage" value="https://www.launchuicomponents.com/" />
+        <option name="urlTemplate" value="https://www.launchuicomponents.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-lens-blocks" />
+        <option name="name" value="Lens-blocks" />
+        <option name="namespace" value="@lens-blocks" />
+        <option name="baseUrl" value="https://lensblocks.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of social media components for use with Lens Social Protocol." />
+        <option name="homepage" value="https://lensblocks.com" />
+        <option name="urlTemplate" value="https://lensblocks.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-limeplay" />
+        <option name="name" value="Limeplay" />
+        <option name="namespace" value="@limeplay" />
+        <option name="baseUrl" value="https://limeplay.winoffrg.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Modern UI Library for building media players in React. Powered by Shaka Player." />
+        <option name="homepage" value="https://limeplay.winoffrg.dev" />
+        <option name="urlTemplate" value="https://limeplay.winoffrg.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-liquefy-ui" />
+        <option name="name" value="Liquefy-ui" />
+        <option name="namespace" value="@liquefy-ui" />
+        <option name="baseUrl" value="https://liquefy-ui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Liquid Glass components for React: WebGL edge refraction and pointer-driven springs over accessible Base UI primitives. TypeScript, RSC-ready, with an MCP server." />
+        <option name="homepage" value="https://liquefy-ui.com" />
+        <option name="urlTemplate" value="https://liquefy-ui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-lmscn" />
+        <option name="name" value="Lmscn" />
+        <option name="namespace" value="@lmscn" />
+        <option name="baseUrl" value="https://lmscn.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="LMS components for building interactive learning experiences — quiz, flashcards, matching, fill-in-the-blank, word scramble, sequencing, reading comprehension, spaced repetition and more." />
+        <option name="homepage" value="https://lmscn.vercel.app" />
+        <option name="urlTemplate" value="https://lmscn.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-loading-ui" />
+        <option name="name" value="Loading-ui" />
+        <option name="namespace" value="@loading-ui" />
+        <option name="baseUrl" value="https://loading-ui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Spinners, loaders, and loading animations for modern web apps. Free and open-source." />
+        <option name="homepage" value="https://loading-ui.com" />
+        <option name="urlTemplate" value="https://loading-ui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-lucide-animated" />
+        <option name="name" value="Lucide-animated" />
+        <option name="namespace" value="@lucide-animated" />
+        <option name="baseUrl" value="https://lucide-animated.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="An open-source collection of smooth animated lucide icons for your projects" />
+        <option name="homepage" value="https://lucide-animated.com" />
+        <option name="urlTemplate" value="https://lucide-animated.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-lumiui" />
+        <option name="name" value="Lumiui" />
+        <option name="namespace" value="@lumiui" />
+        <option name="baseUrl" value="https://www.lumiui.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Composable React components powered by Base UI and Tailwind CSS — Build fast, customize everything." />
+        <option name="homepage" value="https://www.lumiui.dev" />
+        <option name="urlTemplate" value="https://www.lumiui.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-lytenyte" />
+        <option name="name" value="Lytenyte" />
+        <option name="namespace" value="@lytenyte" />
+        <option name="baseUrl" value="https://www.1771technologies.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="LyteNyte Grid is a high performance, light weight, headless, React data grid. Our registry provides LyteNyte Grid themed using Tailwind and the Shadcn theme variables." />
+        <option name="homepage" value="https://www.1771technologies.com" />
+        <option name="urlTemplate" value="https://www.1771technologies.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-magicui" />
+        <option name="name" value="Magicui" />
+        <option name="namespace" value="@magicui" />
+        <option name="baseUrl" value="https://magicui.design/r" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="UI Library for Design Engineers. 150+ free and open-source animated components and effects built with React, Typescript, Tailwind CSS, and Motion. Perfect companion for shadcn/ui." />
+        <option name="homepage" value="https://magicui.design" />
+        <option name="urlTemplate" value="https://magicui.design/r/{name}" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-manifest" />
+        <option name="name" value="Manifest" />
+        <option name="namespace" value="@manifest" />
+        <option name="baseUrl" value="https://ui.manifest.build/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Agentic UI toolkit for building MCP Apps. Open-source components and blocks ready to use within your chat app." />
+        <option name="homepage" value="https://ui.manifest.build" />
+        <option name="urlTemplate" value="https://ui.manifest.build/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-mapcn" />
+        <option name="name" value="Mapcn" />
+        <option name="namespace" value="@mapcn" />
+        <option name="baseUrl" value="https://mapcn.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautiful maps, made simple. Ready to use, customizable map components for React. Built on MapLibre. Styled with Tailwind CSS." />
+        <option name="homepage" value="https://mapcn.dev" />
+        <option name="urlTemplate" value="https://mapcn.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-mksingh" />
+        <option name="name" value="Mksingh" />
+        <option name="namespace" value="@mksingh" />
+        <option name="baseUrl" value="https://mksingh.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A personal registry of production-ready ShadCN components and utilities. Everything is built to drop into your existing ShadCN project with no extra setup." />
+        <option name="homepage" value="https://mksingh.dev/docs" />
+        <option name="urlTemplate" value="https://mksingh.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-moduix-react" />
+        <option name="name" value="Moduix-react" />
+        <option name="namespace" value="@moduix-react" />
+        <option name="baseUrl" value="https://moduix.dev/r/react" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Ark-first React components, blocks, and themes with native CSS, available as a package or a shadcn-compatible copy-owned registry." />
+        <option name="homepage" value="https://moduix.dev" />
+        <option name="urlTemplate" value="https://moduix.dev/r/react/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-moleculeui" />
+        <option name="name" value="Moleculeui" />
+        <option name="namespace" value="@moleculeui" />
+        <option name="baseUrl" value="https://www.moleculeui.design/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A modern React component library focused on intuitive interactions and seamless user experiences." />
+        <option name="homepage" value="https://www.moleculeui.design/" />
+        <option name="urlTemplate" value="https://www.moleculeui.design/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-motion-menu" />
+        <option name="name" value="Motion-menu" />
+        <option name="namespace" value="@motion-menu" />
+        <option name="baseUrl" value="https://motion-menu-two.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="596 motion/3D UI patterns — scroll-driven WebGL, shader passes, spring choreography — as ready HTML/CSS/JS. 26 free, or $149 once for the rest." />
+        <option name="homepage" value="https://motion-menu-two.vercel.app" />
+        <option name="urlTemplate" value="https://motion-menu-two.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-motion-lexicon" />
+        <option name="name" value="Motion-lexicon" />
+        <option name="namespace" value="@motion-lexicon" />
+        <option name="baseUrl" value="https://motion-lexicon.pages.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Copy-ready React page blocks and motion components with bilingual previews, reduced-motion paths, and shadcn Registry delivery." />
+        <option name="homepage" value="https://motion-lexicon.pages.dev" />
+        <option name="urlTemplate" value="https://motion-lexicon.pages.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-motion-primitives" />
+        <option name="name" value="Motion-primitives" />
+        <option name="namespace" value="@motion-primitives" />
+        <option name="baseUrl" value="https://motion-primitives.com/c" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautifully designed motions components. Easy copy-paste. Customizable. Open Source. Built for engineers and designers." />
+        <option name="homepage" value="https://www.motion-primitives.com" />
+        <option name="urlTemplate" value="https://motion-primitives.com/c/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-motiq" />
+        <option name="name" value="Motiq" />
+        <option name="namespace" value="@motiq" />
+        <option name="baseUrl" value="https://motiq.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Production-ready animated React and Next.js components — accessible, reduced-motion-safe and RSC-safe — installable as editable source with the shadcn CLI. Free and open source." />
+        <option name="homepage" value="https://motiq.dev" />
+        <option name="urlTemplate" value="https://motiq.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-mozaika" />
+        <option name="name" value="Mozaika" />
+        <option name="namespace" value="@mozaika" />
+        <option name="baseUrl" value="https://mozaika.design/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Design systems measured from real product UIs — color roles, typography and spacing as themes installable with the shadcn CLI. Free open shelf; companion MCP server for AI coding agents." />
+        <option name="homepage" value="https://mozaika.design" />
+        <option name="urlTemplate" value="https://mozaika.design/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-mui-treasury" />
+        <option name="name" value="Mui-treasury" />
+        <option name="namespace" value="@mui-treasury" />
+        <option name="baseUrl" value="https://mui-treasury.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of hand-crafted interfaces built on top of MUI components" />
+        <option name="homepage" value="https://www.mui-treasury.com" />
+        <option name="urlTemplate" value="https://mui-treasury.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-motokoui" />
+        <option name="name" value="Motokoui" />
+        <option name="namespace" value="@motokoui" />
+        <option name="baseUrl" value="https://www.motokoui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Components, application blocks, templates, and starter kits for modern React applications." />
+        <option name="homepage" value="https://motokoui.com" />
+        <option name="urlTemplate" value="https://www.motokoui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-navui" />
+        <option name="name" value="Navui" />
+        <option name="namespace" value="@navui" />
+        <option name="baseUrl" value="https://ui.navdeepsingh.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="shadcn-compatible components, blocks, and illustrations that adapt to your existing design configuration." />
+        <option name="homepage" value="https://ui.navdeepsingh.dev" />
+        <option name="urlTemplate" value="https://ui.navdeepsingh.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-ncdai" />
+        <option name="name" value="Ncdai" />
+        <option name="namespace" value="@ncdai" />
+        <option name="baseUrl" value="https://chanhdai.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Pixel-perfect, uniquely crafted." />
+        <option name="homepage" value="https://chanhdai.com/components" />
+        <option name="urlTemplate" value="https://chanhdai.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-neobrutalism" />
+        <option name="name" value="Neobrutalism" />
+        <option name="namespace" value="@neobrutalism" />
+        <option name="baseUrl" value="https://www.neobrutalism.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of neobrutalism-styled components based on shadcn/ui" />
+        <option name="homepage" value="https://www.neobrutalism.dev" />
+        <option name="urlTemplate" value="https://www.neobrutalism.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-neon-ui" />
+        <option name="name" value="Neon-ui" />
+        <option name="namespace" value="@neon-ui" />
+        <option name="baseUrl" value="https://ui.neon.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Production-ready components for agent platforms built on Neon. Database branching, connection strings, usage metering and project management UI, built with Base UI and Tailwind v4." />
+        <option name="homepage" value="https://ui.neon.com" />
+        <option name="urlTemplate" value="https://ui.neon.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-nessra-ui" />
+        <option name="name" value="Nessra-ui" />
+        <option name="namespace" value="@nessra-ui" />
+        <option name="baseUrl" value="https://nessra-ui.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautiful, accessible components built with Tailwind CSS v4 and Radix UI. Includes auth blocks, data tables, and TanStack Form integration." />
+        <option name="homepage" value="https://nessra-ui.vercel.app" />
+        <option name="urlTemplate" value="https://nessra-ui.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-nexus-elements" />
+        <option name="name" value="Nexus-elements" />
+        <option name="namespace" value="@nexus-elements" />
+        <option name="baseUrl" value="https://elements.nexus.availproject.org/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Ready-made React components for almost any use case. Use as is or customise and go to market fast" />
+        <option name="homepage" value="https://elements.nexus.availproject.org/docs/view-components" />
+        <option name="urlTemplate" value="https://elements.nexus.availproject.org/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-nexus-labs" />
+        <option name="name" value="Nexus-labs" />
+        <option name="namespace" value="@nexus-labs" />
+        <option name="baseUrl" value="https://nexus-ui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Motion-native animated components for Next.js — backgrounds, heroes, inputs, carousels, and more. Open source. Copy-ready TypeScript." />
+        <option name="homepage" value="https://nexus-ui.com" />
+        <option name="urlTemplate" value="https://nexus-ui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-nexus-ui" />
+        <option name="name" value="Nexus-ui" />
+        <option name="namespace" value="@nexus-ui" />
+        <option name="baseUrl" value="https://nexus-ui.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Open-source component library of composable, copy-paste primitives for building AI interfaces (chat, streaming, multimodal)" />
+        <option name="homepage" value="https://nexus-ui.dev" />
+        <option name="urlTemplate" value="https://nexus-ui.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-nordaun" />
+        <option name="name" value="Nordaun" />
+        <option name="namespace" value="@nordaun" />
+        <option name="baseUrl" value="https://ui.nordaun.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Simple components for your extraordinary creations." />
+        <option name="homepage" value="https://ui.nordaun.com" />
+        <option name="urlTemplate" value="https://ui.nordaun.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-nteract" />
+        <option name="name" value="Nteract" />
+        <option name="namespace" value="@nteract" />
+        <option name="baseUrl" value="https://nteract-elements.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Components for interactive computing notebooks." />
+        <option name="homepage" value="https://nteract-elements.vercel.app/" />
+        <option name="urlTemplate" value="https://nteract-elements.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-nuqs" />
+        <option name="name" value="Nuqs" />
+        <option name="namespace" value="@nuqs" />
+        <option name="baseUrl" value="https://nuqs.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Custom parsers, adapters and utilities from the community for type-safe URL state management." />
+        <option name="homepage" value="https://nuqs.dev/registry" />
+        <option name="urlTemplate" value="https://nuqs.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-nusaiba" />
+        <option name="name" value="Nusaiba" />
+        <option name="namespace" value="@nusaiba" />
+        <option name="baseUrl" value="https://nusaiba.dev/r/base-nova" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Motion-first shadcn marketing blocks for landing pages — heroes, pricing, FAQs, footers, and more. Built on base-nova with intentional animation and CLI install." />
+        <option name="homepage" value="https://nusaiba.dev" />
+        <option name="urlTemplate" value="https://nusaiba.dev/r/base-nova/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-odysseyui" />
+        <option name="name" value="Odysseyui" />
+        <option name="namespace" value="@odysseyui" />
+        <option name="baseUrl" value="https://www.odysseyui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A design focused component library for Next.js, built for speed, flexibility and developer experience." />
+        <option name="homepage" value="https://www.odysseyui.com/docs" />
+        <option name="urlTemplate" value="https://www.odysseyui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-ogimagecn" />
+        <option name="name" value="Ogimagecn" />
+        <option name="namespace" value="@ogimagecn" />
+        <option name="baseUrl" value="https://ogimagecn.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautiful OG images, made simple. Ready to use, customizable Open Graph image components for React." />
+        <option name="homepage" value="https://ogimagecn.vercel.app" />
+        <option name="urlTemplate" value="https://ogimagecn.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-openpolicy" />
+        <option name="name" value="Openpolicy" />
+        <option name="namespace" value="@openpolicy" />
+        <option name="baseUrl" value="https://www.openpolicy.sh/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Open-source components for building terms, privacy policies and cookie banners." />
+        <option name="homepage" value="https://www.openpolicy.sh" />
+        <option name="urlTemplate" value="https://www.openpolicy.sh/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-openstatus" />
+        <option name="name" value="Openstatus" />
+        <option name="namespace" value="@openstatus" />
+        <option name="baseUrl" value="https://openstatus.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Hand-crafted, accessible components for building beautiful status pages." />
+        <option name="homepage" value="https://openstatus.dev/registry" />
+        <option name="urlTemplate" value="https://openstatus.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-openmirai" />
+        <option name="name" value="Openmirai" />
+        <option name="namespace" value="@openmirai" />
+        <option name="baseUrl" value="https://www.openmirai.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Open-source React and TypeScript tools from OpenMirai." />
+        <option name="homepage" value="https://www.openmirai.dev" />
+        <option name="urlTemplate" value="https://www.openmirai.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-optics" />
+        <option name="name" value="Optics" />
+        <option name="namespace" value="@optics" />
+        <option name="baseUrl" value="https://optics.agusmayol.com.ar/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A design system that distributes re-styled components, utilities, and hooks ready to use." />
+        <option name="homepage" value="https://optics.agusmayol.com.ar" />
+        <option name="urlTemplate" value="https://optics.agusmayol.com.ar/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-oui" />
+        <option name="name" value="Oui" />
+        <option name="namespace" value="@oui" />
+        <option name="baseUrl" value="https://oui.mw10013.workers.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="React Aria Components with shadcn characteristics.Copy-and-paste react aria components that run side-by-side with shadcn components." />
+        <option name="homepage" value="https://oui.mw10013.workers.dev" />
+        <option name="urlTemplate" value="https://oui.mw10013.workers.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-paceui" />
+        <option name="name" value="Paceui" />
+        <option name="namespace" value="@paceui" />
+        <option name="baseUrl" value="https://paceui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Carefully built UI blocks for real apps and dashboards, designed to integrate smoothly from early ideas to production releases." />
+        <option name="homepage" value="https://paceui.com" />
+        <option name="urlTemplate" value="https://paceui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-pacekit" />
+        <option name="name" value="Pacekit" />
+        <option name="namespace" value="@pacekit" />
+        <option name="baseUrl" value="https://ui.pacekit.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Carefully built UI blocks for real apps and dashboards, designed to integrate smoothly from early ideas to production releases." />
+        <option name="homepage" value="https://ui.pacekit.dev" />
+        <option name="urlTemplate" value="https://ui.pacekit.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-paceui-gsap" />
+        <option name="name" value="Paceui-gsap" />
+        <option name="namespace" value="@paceui-gsap" />
+        <option name="baseUrl" value="https://gsap.paceui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Animated GSAP components crafted for smooth interaction and rich detail." />
+        <option name="homepage" value="https://gsap.paceui.com" />
+        <option name="urlTemplate" value="https://gsap.paceui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-paddle" />
+        <option name="name" value="Paddle" />
+        <option name="namespace" value="@paddle" />
+        <option name="baseUrl" value="https://developer.paddle.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Drop-in components for building checkouts, pricing pages, and subscription management screens using Paddle Billing." />
+        <option name="homepage" value="https://developer.paddle.com/" />
+        <option name="urlTemplate" value="https://developer.paddle.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-paletteui" />
+        <option name="name" value="Paletteui" />
+        <option name="namespace" value="@paletteui" />
+        <option name="baseUrl" value="https://paletteui.xyz/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Curated OKLCH color themes for shadcn/ui + visual theme editor with CSS, Tailwind v4, and Figma export." />
+        <option name="homepage" value="https://paletteui.xyz" />
+        <option name="urlTemplate" value="https://paletteui.xyz/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-payload-components" />
+        <option name="name" value="Payload-components" />
+        <option name="namespace" value="@payload-components" />
+        <option name="baseUrl" value="https://www.payload-components.xyz/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="MIT registry of typed Payload CMS blocks for Payload v3 + Next.js. Each block installs as reviewable source; the companion CLI also wires collection config, RenderBlocks, types, and the admin import map." />
+        <option name="homepage" value="https://www.payload-components.xyz" />
+        <option name="urlTemplate" value="https://www.payload-components.xyz/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-pastecn" />
+        <option name="name" value="Pastecn" />
+        <option name="namespace" value="@pastecn" />
+        <option name="baseUrl" value="https://pastecn.com/r" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="pastebin + shadcn = pastecn. Paste your code and get a shadcn-compatible registry URL instantly." />
+        <option name="homepage" value="https://pastecn.com" />
+        <option name="urlTemplate" value="https://pastecn.com/r/{name}" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-paykit-sdk" />
+        <option name="name" value="Paykit-sdk" />
+        <option name="namespace" value="@paykit-sdk" />
+        <option name="baseUrl" value="https://www.usepaykit.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Unified payments SDK for builders — handle checkout, billing, and webhooks across Stripe, PayPal, Adyen, and regional gateways with a single integration." />
+        <option name="homepage" value="https://www.usepaykit.dev" />
+        <option name="urlTemplate" value="https://www.usepaykit.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-phucbm" />
+        <option name="name" value="Phucbm" />
+        <option name="namespace" value="@phucbm" />
+        <option name="baseUrl" value="https://phucbm.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of modern React UI components with GSAP animations." />
+        <option name="homepage" value="https://phucbm.com/components" />
+        <option name="urlTemplate" value="https://phucbm.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-pixelact-ui" />
+        <option name="name" value="Pixelact-ui" />
+        <option name="namespace" value="@pixelact-ui" />
+        <option name="baseUrl" value="https://pixelactui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Playful pixel art style components library built on top of shadcn. Perfect for retro style projects and games." />
+        <option name="homepage" value="https://pixelactui.com" />
+        <option name="urlTemplate" value="https://pixelactui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-plate" />
+        <option name="name" value="Plate" />
+        <option name="namespace" value="@plate" />
+        <option name="baseUrl" value="https://platejs.org/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="AI-powered rich text editor for React." />
+        <option name="homepage" value="https://platejs.org" />
+        <option name="urlTemplate" value="https://platejs.org/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-preskok" />
+        <option name="name" value="Preskok" />
+        <option name="namespace" value="@preskok" />
+        <option name="baseUrl" value="https://ui-three-mu.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Accessible, production-ready React components built with React Aria Components and Tailwind CSS." />
+        <option name="homepage" value="https://ui-three-mu.vercel.app" />
+        <option name="urlTemplate" value="https://ui-three-mu.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-persianlabsui" />
+        <option name="name" value="Persianlabsui" />
+        <option name="namespace" value="@persianlabsui" />
+        <option name="baseUrl" value="https://ui.persian-labs.ir/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="RTL-first, copy-paste React components and UI blocks for Persian interfaces, built on Base UI and Tailwind CSS. Includes unique Persian-focused patterns with full LTR support." />
+        <option name="homepage" value="https://ui.persian-labs.ir" />
+        <option name="urlTemplate" value="https://ui.persian-labs.ir/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-prompt-kit" />
+        <option name="name" value="Prompt-kit" />
+        <option name="namespace" value="@prompt-kit" />
+        <option name="baseUrl" value="https://www.prompt-kit.com/c" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Core building blocks for AI apps. High-quality, accessible, and customizable components for AI interfaces." />
+        <option name="homepage" value="https://www.prompt-kit.com" />
+        <option name="urlTemplate" value="https://www.prompt-kit.com/c/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-prosekit" />
+        <option name="name" value="Prosekit" />
+        <option name="namespace" value="@prosekit" />
+        <option name="baseUrl" value="https://prosekit.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Powerful and flexible rich text editor for React, Vue, Preact, Svelte, and SolidJS." />
+        <option name="homepage" value="https://prosekit.dev" />
+        <option name="urlTemplate" value="https://prosekit.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-pulkitxm" />
+        <option name="name" value="Pulkitxm" />
+        <option name="namespace" value="@pulkitxm" />
+        <option name="baseUrl" value="https://pulkit.page/components" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Animated shadcn components powered by GSAP and Framer Motion. Built for expressive UIs." />
+        <option name="homepage" value="https://pulkit.page" />
+        <option name="urlTemplate" value="https://pulkit.page/components/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-pulld" />
+        <option name="name" value="Pulld" />
+        <option name="namespace" value="@pulld" />
+        <option name="baseUrl" value="https://pulld.pages.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Typed, accessible, theme-aware React/Tailwind components installable by the shadcn CLI or your AI coding agent. Free atoms plus composed Pro blocks." />
+        <option name="homepage" value="https://pulld.pages.dev" />
+        <option name="urlTemplate" value="https://pulld.pages.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-pureui" />
+        <option name="name" value="Pureui" />
+        <option name="namespace" value="@pureui" />
+        <option name="baseUrl" value="https://pure.kam-ui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Pure UI is a curated collection of refined, animated, and accessible components built with Base UI, Tailwind CSS, Motion, and other high-quality open source libraries." />
+        <option name="homepage" value="https://pure.kam-ui.com/" />
+        <option name="urlTemplate" value="https://pure.kam-ui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-ramonclaudio-coderabbit" />
+        <option name="name" value="Ramonclaudio-coderabbit" />
+        <option name="namespace" value="@ramonclaudio-coderabbit" />
+        <option name="baseUrl" value="https://coderabbit-shadcn-registry.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A framework-agnostic API client, pluggable storage adapters (LocalStorage, Convex, Supabase, PostgreSQL, MySQL), and React components for generating developer activity reports." />
+        <option name="homepage" value="https://ramonclaudio.com/registries/coderabbit" />
+        <option name="urlTemplate" value="https://coderabbit-shadcn-registry.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-react-aria" />
+        <option name="name" value="React-aria" />
+        <option name="namespace" value="@react-aria" />
+        <option name="baseUrl" value="https://react-aria.adobe.com/registry" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Customizable Tailwind and Vanilla CSS components with adaptive interactions, top-tier accessibility, and internationalization." />
+        <option name="homepage" value="https://react-aria.adobe.com" />
+        <option name="urlTemplate" value="https://react-aria.adobe.com/registry/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-react-bits" />
+        <option name="name" value="React-bits" />
+        <option name="namespace" value="@react-bits" />
+        <option name="baseUrl" value="https://reactbits.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A large collection of animated, interactive &amp; fully customizable React components for building memorable websites. From smooth text animations all the way to eye-catching backgrounds, you can find it here." />
+        <option name="homepage" value="https://reactbits.dev" />
+        <option name="urlTemplate" value="https://reactbits.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-react-easy-modals" />
+        <option name="name" value="React-easy-modals" />
+        <option name="namespace" value="@react-easy-modals" />
+        <option name="baseUrl" value="https://react-easy-modals-docs.vercel.app/r/styles/{style}" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Modal component for react-easy-modals. Integrates with shadcn Dialog for a simple, powerful modal system with TypeScript support and promise-based API." />
+        <option name="homepage" value="https://react-easy-modals-docs.vercel.app" />
+        <option name="urlTemplate" value="https://react-easy-modals-docs.vercel.app/r/styles/{style}/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-react-slot" />
+        <option name="name" value="React-slot" />
+        <option name="namespace" value="@react-slot" />
+        <option name="baseUrl" value="https://react-slot.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Vue-style slot composition for React - Fine-grained control over component composition" />
+        <option name="homepage" value="https://react-slot.vercel.app/" />
+        <option name="urlTemplate" value="https://react-slot.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-remocn" />
+        <option name="name" value="Remocn" />
+        <option name="namespace" value="@remocn" />
+        <option name="baseUrl" value="https://www.remocn.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Production-ready components for Remotion - text animations, backgrounds, transitions, UI blocks, and full scene compositions" />
+        <option name="homepage" value="https://www.remocn.dev/" />
+        <option name="urlTemplate" value="https://www.remocn.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-rescript-shadcn" />
+        <option name="name" value="Rescript-shadcn" />
+        <option name="namespace" value="@rescript-shadcn" />
+        <option name="baseUrl" value="https://rescript-shadcn.miriad.studio/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Shadcn components rewritten in Rescript, compatible with shadcn CLI." />
+        <option name="homepage" value="https://rescript-shadcn.miriad.studio" />
+        <option name="urlTemplate" value="https://rescript-shadcn.miriad.studio/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-retab" />
+        <option name="name" value="Retab" />
+        <option name="namespace" value="@retab" />
+        <option name="baseUrl" value="https://ui.retab.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Document-processing UI components for Retab — file, OCR, and data viewers, schema builders, dropzones, and extraction blocks, built on shadcn/ui." />
+        <option name="homepage" value="https://ui.retab.com" />
+        <option name="urlTemplate" value="https://ui.retab.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-retroui" />
+        <option name="name" value="Retroui" />
+        <option name="namespace" value="@retroui" />
+        <option name="baseUrl" value="https://retroui.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A Neobrutalism styled React + TailwindCSS UI library for building bold, modern web apps. Perfect for any project using Shadcn/ui." />
+        <option name="homepage" value="https://retroui.dev" />
+        <option name="urlTemplate" value="https://retroui.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-reui" />
+        <option name="name" value="Reui" />
+        <option name="namespace" value="@reui" />
+        <option name="baseUrl" value="https://reui.io/r/{style}" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Free &amp; open-source library of 1,000+ components and patterns to 10x your productivity in shadcn projects." />
+        <option name="homepage" value="https://reui.io" />
+        <option name="urlTemplate" value="https://reui.io/r/{style}/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-roiui" />
+        <option name="name" value="Roiui" />
+        <option name="namespace" value="@roiui" />
+        <option name="baseUrl" value="https://roiui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Roi UI is a library that offers UI components and blocks built with Base UI primitives. Some blocks and components use motion (framer). Everything is open-source and will be forever." />
+        <option name="homepage" value="https://roiui.com" />
+        <option name="urlTemplate" value="https://roiui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-sabraman" />
+        <option name="name" value="Sabraman" />
+        <option name="namespace" value="@sabraman" />
+        <option name="baseUrl" value="https://sabraman.ru/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Legacy skeuomorphic UI components and blocks for shadcn." />
+        <option name="homepage" value="https://sabraman.ru/components" />
+        <option name="urlTemplate" value="https://sabraman.ru/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-satoriui" />
+        <option name="name" value="Satoriui" />
+        <option name="namespace" value="@satoriui" />
+        <option name="baseUrl" value="https://satoriui.site/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A comprehensive suite of high-fidelity interaction components. It offers motion-driven components that designed with motion-react and tailwindcss, that blends seamlessly." />
+        <option name="homepage" value="https://satoriui.site" />
+        <option name="urlTemplate" value="https://satoriui.site/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-scrollxui" />
+        <option name="name" value="Scrollxui" />
+        <option name="namespace" value="@scrollxui" />
+        <option name="baseUrl" value="https://www.scrollxui.dev/registry" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="ScrollX UI is an open-source React and shadcn-compatible component library for animated, interactive, and customizable user interfaces. It offers motion-driven components that blend seamlessly with modern ShadCN setups." />
+        <option name="homepage" value="https://www.scrollxui.dev" />
+        <option name="urlTemplate" value="https://www.scrollxui.dev/registry/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-seamui" />
+        <option name="name" value="Seamui" />
+        <option name="namespace" value="@seamui" />
+        <option name="baseUrl" value="https://seamui.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Own-your-code components rebuilt on Base UI with a motion.dev feel layer — springs, touch feedback, and depth — plus an agent-workbench tier (composer, voice, status, connectors) for AI-era interfaces." />
+        <option name="homepage" value="https://seamui.dev" />
+        <option name="urlTemplate" value="https://seamui.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-shadcn-editor" />
+        <option name="name" value="Shadcn-editor" />
+        <option name="namespace" value="@shadcn-editor" />
+        <option name="baseUrl" value="https://raw.githubusercontent.com/htmujahid/shadcn-editor/refs/heads/main/public/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Accessible, Customizable, Rich Text Editor. Made with Lexical and Shadcn/UI. Open Source. Open Code." />
+        <option name="homepage" value="https://shadcn-editor.vercel.app" />
+        <option name="urlTemplate" value="https://raw.githubusercontent.com/htmujahid/shadcn-editor/refs/heads/main/public/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-shadcn-map" />
+        <option name="name" value="Shadcn-map" />
+        <option name="namespace" value="@shadcn-map" />
+        <option name="baseUrl" value="http://shadcn-map.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A map component for shadcn/ui. Built with Leaflet and React Leaflet." />
+        <option name="homepage" value="https://shadcn-map.vercel.app" />
+        <option name="urlTemplate" value="http://shadcn-map.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-shadcn-space" />
+        <option name="name" value="Shadcn-space" />
+        <option name="namespace" value="@shadcn-space" />
+        <option name="baseUrl" value="https://shadcnspace.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="ShadcnSpace is a collection of extra-ordinary, highly customizable shadcn/ui components, blocks, and themes to build modern UIs with speed and clarity." />
+        <option name="homepage" value="https://shadcnspace.com" />
+        <option name="urlTemplate" value="https://shadcnspace.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-shadcn-studio" />
+        <option name="name" value="Shadcn-studio" />
+        <option name="namespace" value="@shadcn-studio" />
+        <option name="baseUrl" value="https://shadcnstudio.com/r/{style}" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="An open-source set of shadcn/ui components, blocks, and templates with a powerful theme generator." />
+        <option name="homepage" value="https://shadcnstudio.com" />
+        <option name="urlTemplate" value="https://shadcnstudio.com/r/{style}/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-shadcn-ui-blocks" />
+        <option name="name" value="Shadcn-ui-blocks" />
+        <option name="namespace" value="@shadcn-ui-blocks" />
+        <option name="baseUrl" value="https://www.shadcn-ui-blocks.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Shadcn blocks across standard collections and handcrafted premium collections, plus a beautiful templates. Start free, then unlock more with Pro." />
+        <option name="homepage" value="https://www.shadcn-ui-blocks.com" />
+        <option name="urlTemplate" value="https://www.shadcn-ui-blocks.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-shadcnblocks" />
+        <option name="name" value="Shadcnblocks" />
+        <option name="namespace" value="@shadcnblocks" />
+        <option name="baseUrl" value="https://shadcnblocks.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A shadcn/ui registry with 1429 blocks, 1189 component variants, 14 templates, themes, and admin dashboard patterns." />
+        <option name="homepage" value="https://shadcnblocks.com" />
+        <option name="urlTemplate" value="https://shadcnblocks.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-shadcncraft" />
+        <option name="name" value="Shadcncraft" />
+        <option name="namespace" value="@shadcncraft" />
+        <option name="baseUrl" value="https://shadcncraft.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A starter collection of polished shadcn/ui components and blocks built to production standards. Part of a larger Figma + React system designed to scale with your product." />
+        <option name="homepage" value="https://shadcncraft.com" />
+        <option name="urlTemplate" value="https://shadcncraft.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-shadcndesign" />
+        <option name="name" value="Shadcndesign" />
+        <option name="namespace" value="@shadcndesign" />
+        <option name="baseUrl" value="https://shadcndesign-free.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A growing collection of high-quality blocks and themes for shadcn/ui." />
+        <option name="homepage" value="https://www.shadcndesign.com" />
+        <option name="urlTemplate" value="https://shadcndesign-free.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-shadcnhooks" />
+        <option name="name" value="Shadcnhooks" />
+        <option name="namespace" value="@shadcnhooks" />
+        <option name="baseUrl" value="https://shadcn-hooks.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A comprehensive React Hooks Collection built with Shadcn." />
+        <option name="homepage" value="https://shadcn-hooks.com" />
+        <option name="urlTemplate" value="https://shadcn-hooks.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-shadcnmaps" />
+        <option name="name" value="Shadcnmaps" />
+        <option name="namespace" value="@shadcnmaps" />
+        <option name="baseUrl" value="https://shadcnmaps.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautiful map components powered by pure SVG." />
+        <option name="homepage" value="https://shadcnmaps.com" />
+        <option name="urlTemplate" value="https://shadcnmaps.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-shadcnstore" />
+        <option name="name" value="Shadcnstore" />
+        <option name="namespace" value="@shadcnstore" />
+        <option name="baseUrl" value="https://shadcnstore.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A growing collection of shadcn/ui components, blocks, and templates for building modern web apps." />
+        <option name="homepage" value="https://www.shadcnstore.com" />
+        <option name="urlTemplate" value="https://shadcnstore.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-shadcnui-blocks" />
+        <option name="name" value="Shadcnui-blocks" />
+        <option name="namespace" value="@shadcnui-blocks" />
+        <option name="baseUrl" value="https://shadcnui-blocks.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of premium, production-ready shadcn/ui blocks, components and templates." />
+        <option name="homepage" value="https://shadcnui-blocks.com" />
+        <option name="urlTemplate" value="https://shadcnui-blocks.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-shadcnuikit" />
+        <option name="name" value="Shadcnuikit" />
+        <option name="namespace" value="@shadcnuikit" />
+        <option name="baseUrl" value="https://shadcnuikit.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Launch your projects faster with admin dashboards, website templates, components, blocks, and pre-built real-world examples." />
+        <option name="homepage" value="https://shadcnuikit.com" />
+        <option name="urlTemplate" value="https://shadcnuikit.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-shark" />
+        <option name="name" value="Shark" />
+        <option name="namespace" value="@shark" />
+        <option name="baseUrl" value="https://shark.vini.one/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="shadcn/ui-style components built on Ark UI." />
+        <option name="homepage" value="https://shark.vini.one" />
+        <option name="urlTemplate" value="https://shark.vini.one/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-shieldcn" />
+        <option name="name" value="Shieldcn" />
+        <option name="namespace" value="@shieldcn" />
+        <option name="baseUrl" value="https://shieldcn.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautiful README badges as a service. A shields.io alternative with the visual quality of shadcn/ui. Drop-in SVG badge components for npm, GitHub, Discord, and more." />
+        <option name="homepage" value="https://shieldcn.dev" />
+        <option name="urlTemplate" value="https://shieldcn.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-shoogle" />
+        <option name="name" value="Shoogle" />
+        <option name="namespace" value="@shoogle" />
+        <option name="baseUrl" value="https://shoogle.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Search shadcn blocks and components across community registries from the CLI" />
+        <option name="homepage" value="https://shoogle.dev" />
+        <option name="urlTemplate" value="https://shoogle.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-skiper-ui" />
+        <option name="name" value="Skiper-ui" />
+        <option name="namespace" value="@skiper-ui" />
+        <option name="baseUrl" value="https://skiper-ui.com/registry" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Brand new uncommon components for your Next.js project. Use with ease through shadcn CLI 3.0, featuring fast-growing components and collections that are easy to edit and use." />
+        <option name="homepage" value="https://skiper-ui.com/" />
+        <option name="urlTemplate" value="https://skiper-ui.com/registry/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-slide-cn" />
+        <option name="name" value="Slide-cn" />
+        <option name="namespace" value="@slide-cn" />
+        <option name="baseUrl" value="https://slide-cn.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A component library to build slide decks using code." />
+        <option name="homepage" value="https://slide-cn.com" />
+        <option name="urlTemplate" value="https://slide-cn.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-smoothui" />
+        <option name="name" value="Smoothui" />
+        <option name="namespace" value="@smoothui" />
+        <option name="baseUrl" value="https://smoothui.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of beautifully crafted motion components built with React, Framer Motion, and TailwindCSS. Designed to elevate microinteractions, each component focuses on smooth animations, subtle feedback, and delightful UX. Perfect for designers and developers who want to add refined motion to their interfaces — copy, paste, and make your UI come alive." />
+        <option name="homepage" value="https://smoothui.dev" />
+        <option name="urlTemplate" value="https://smoothui.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-snapcn" />
+        <option name="name" value="Snapcn" />
+        <option name="namespace" value="@snapcn" />
+        <option name="baseUrl" value="https://snapcn.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Remotion video components for React. Text reveals, karaoke captions, device mockups, logo stings and full scenes, installed with the CLI and owned as source." />
+        <option name="homepage" value="https://snapcn.dev" />
+        <option name="urlTemplate" value="https://snapcn.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-solaceui" />
+        <option name="name" value="Solaceui" />
+        <option name="namespace" value="@solaceui" />
+        <option name="baseUrl" value="https://www.solaceui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Production-ready and tastefully crafted sections, animated components, and full-page templates for Next.js, Tailwind CSS &amp; Motion" />
+        <option name="homepage" value="https://www.solaceui.com" />
+        <option name="urlTemplate" value="https://www.solaceui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-sona-ui" />
+        <option name="name" value="Sona-ui" />
+        <option name="namespace" value="@sona-ui" />
+        <option name="baseUrl" value="https://sona-ui.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A modern UI component library built with React and TailwindCSS to help you build beautiful and accessible web applications faster." />
+        <option name="homepage" value="https://sona-ui.vercel.app" />
+        <option name="urlTemplate" value="https://sona-ui.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-soralabs" />
+        <option name="name" value="Soralabs" />
+        <option name="namespace" value="@soralabs" />
+        <option name="baseUrl" value="https://ui.soralabs.io.vn/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Motion-first React primitives and animated UI components for shadcn/ui. Copy, customize, and ship fluid interfaces." />
+        <option name="homepage" value="https://ui.soralabs.io.vn" />
+        <option name="urlTemplate" value="https://ui.soralabs.io.vn/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-soundcn" />
+        <option name="name" value="Soundcn" />
+        <option name="namespace" value="@soundcn" />
+        <option name="baseUrl" value="https://soundcn.xyz/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Large collection of game, interface, retro, and voice sound effects for web applications" />
+        <option name="homepage" value="https://soundcn.xyz" />
+        <option name="urlTemplate" value="https://soundcn.xyz/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-spectrumui" />
+        <option name="name" value="Spectrumui" />
+        <option name="namespace" value="@spectrumui" />
+        <option name="baseUrl" value="https://ui.spectrumhq.in/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A modern component library built with shadcn/ui and Tailwind CSS. Spectrum UI offers elegant, responsive components and smooth animations designed for high-quality interfaces." />
+        <option name="homepage" value="https://ui.spectrumhq.in" />
+        <option name="urlTemplate" value="https://ui.spectrumhq.in/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-spell" />
+        <option name="name" value="Spell" />
+        <option name="namespace" value="@spell" />
+        <option name="baseUrl" value="https://spell.sh/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautiful, sophisticated UI components designed for modern React and Tailwind CSS applications." />
+        <option name="homepage" value="https://spell.sh" />
+        <option name="urlTemplate" value="https://spell.sh/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-square-ui" />
+        <option name="name" value="Square-ui" />
+        <option name="namespace" value="@square-ui" />
+        <option name="baseUrl" value="https://square.lndev.me/registry" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Collection of beautifully crafted open-source layouts UI built with shadcn/ui." />
+        <option name="homepage" value="https://square.lndev.me" />
+        <option name="urlTemplate" value="https://square.lndev.me/registry/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-stepper" />
+        <option name="name" value="Stepper" />
+        <option name="namespace" value="@stepper" />
+        <option name="baseUrl" value="https://francozeta-stepper.vercel.app" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A modern, accessible and composable Stepper component for React and Tailwind CSS. Built for shadcn/ui-style workflows with registry-first distribution." />
+        <option name="homepage" value="https://francozeta-stepper.vercel.app" />
+        <option name="urlTemplate" value="https://francozeta-stepper.vercel.app/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-supabase" />
+        <option name="name" value="Supabase" />
+        <option name="namespace" value="@supabase" />
+        <option name="baseUrl" value="https://supabase.com/ui/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of React components and blocks built on the shadcn/ui library that connect your front-end to your Supabase back-end via a single command." />
+        <option name="homepage" value="https://supabase.com/ui" />
+        <option name="urlTemplate" value="https://supabase.com/ui/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-svgl" />
+        <option name="name" value="Svgl" />
+        <option name="namespace" value="@svgl" />
+        <option name="baseUrl" value="https://svgl.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A beautiful library with SVG logos." />
+        <option name="homepage" value="https://svgl.app" />
+        <option name="urlTemplate" value="https://svgl.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-systaliko-ui" />
+        <option name="name" value="Systaliko-ui" />
+        <option name="namespace" value="@systaliko-ui" />
+        <option name="baseUrl" value="https://systaliko-ui.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="UI component library, Designed for flexibility, built for customization, and crafted to scale across variants and use cases." />
+        <option name="homepage" value="https://systaliko-ui.vercel.app" />
+        <option name="urlTemplate" value="https://systaliko-ui.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-tailark" />
+        <option name="name" value="Tailark" />
+        <option name="namespace" value="@tailark" />
+        <option name="baseUrl" value="https://tailark.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Shadcn blocks designed for building modern marketing websites." />
+        <option name="homepage" value="https://tailark.com" />
+        <option name="urlTemplate" value="https://tailark.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-tailgrids" />
+        <option name="name" value="Tailgrids" />
+        <option name="namespace" value="@tailgrids" />
+        <option name="baseUrl" value="https://tailgrids.com/docs/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="React UI Components, Powered by Tailwind CSS" />
+        <option name="homepage" value="https://tailgrids.com" />
+        <option name="urlTemplate" value="https://tailgrids.com/docs/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-tailwind-admin" />
+        <option name="name" value="Tailwind-admin" />
+        <option name="namespace" value="@tailwind-admin" />
+        <option name="baseUrl" value="https://tailwind-admin.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Tailwind Builder provides free tailwind admin dashboard templates, components and ui-blocks built with React, Next.js, Tailwind CSS, and shadcn/ui to help you build admin panels quickly and efficiently." />
+        <option name="homepage" value="https://tailwind-admin.com/" />
+        <option name="urlTemplate" value="https://tailwind-admin.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-tailwind-builder" />
+        <option name="name" value="Tailwind-builder" />
+        <option name="namespace" value="@tailwind-builder" />
+        <option name="baseUrl" value="https://tailwindbuilder.ai/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Tailwind Builder is a collection of free ui blocks and components and provide ai tools to generate production-ready forms, tables, and charts in seconds. Built with React, Next.js, Tailwind &amp; ShadCN." />
+        <option name="homepage" value="https://tailwindbuilder.ai/" />
+        <option name="urlTemplate" value="https://tailwindbuilder.ai/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-taki" />
+        <option name="name" value="Taki" />
+        <option name="namespace" value="@taki" />
+        <option name="baseUrl" value="https://taki-ui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautifully designed, accessible components that you can copy and paste into your apps. Made with React Aria Components and Shadcn tokens." />
+        <option name="homepage" value="https://taki-ui.com" />
+        <option name="urlTemplate" value="https://taki-ui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-termcn" />
+        <option name="name" value="Termcn" />
+        <option name="namespace" value="@termcn" />
+        <option name="baseUrl" value="https://termcn.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautiful terminal UIs, made simple. Ready to use, customizable terminal UI components for React." />
+        <option name="homepage" value="https://termcn.vercel.app" />
+        <option name="urlTemplate" value="https://termcn.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-tuiparts" />
+        <option name="name" value="Tuiparts" />
+        <option name="namespace" value="@tuiparts" />
+        <option name="baseUrl" value="https://tuiparts.sh/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="OpenTUI recipes, made simple. Ready to use, customizable terminal UI recipes for Core, React, and Solid." />
+        <option name="homepage" value="https://tuiparts.sh" />
+        <option name="urlTemplate" value="https://tuiparts.sh/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-terrae" />
+        <option name="name" value="Terrae" />
+        <option name="namespace" value="@terrae" />
+        <option name="baseUrl" value="https://www.terrae.dev" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Composable, animated map components for React. Built with TypeScript, Tailwind CSS, Mapbox GL JS, and MapLibre GL. Perfect companion for shadcn/ui." />
+        <option name="homepage" value="https://www.terrae.dev" />
+        <option name="urlTemplate" value="https://www.terrae.dev/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-tetra-ui" />
+        <option name="name" value="Tetra-ui" />
+        <option name="namespace" value="@tetra-ui" />
+        <option name="baseUrl" value="https://tetra-ui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Delightful components for a clean, accessible and modern component library for React Native." />
+        <option name="homepage" value="https://tetra-ui.com" />
+        <option name="urlTemplate" value="https://tetra-ui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-text-ui" />
+        <option name="name" value="Text-ui" />
+        <option name="namespace" value="@text-ui" />
+        <option name="baseUrl" value="https://joelachance.github.io/text-ui/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A shadcn/ui registry with EchoText (`echo-text`): layered stroke text that follows the pointer—minimal setup, drop-in component." />
+        <option name="homepage" value="https://joelachance.github.io/text-ui/docs" />
+        <option name="urlTemplate" value="https://joelachance.github.io/text-ui/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-thegridcn" />
+        <option name="name" value="Thegridcn" />
+        <option name="namespace" value="@thegridcn" />
+        <option name="baseUrl" value="https://thegridcn.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A Tron-inspired shadcn/ui theme system with Greek god color schemes, glow intensity levels, and sci-fi components like DataCard, HUD, Radar, and more." />
+        <option name="homepage" value="https://thegridcn.com" />
+        <option name="urlTemplate" value="https://thegridcn.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-toc-cn" />
+        <option name="name" value="Toc-cn" />
+        <option name="namespace" value="@toc-cn" />
+        <option name="baseUrl" value="https://tocn.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Documentation-style in-page table of contents with scroll spy, animated SVG tree indicator, and mobile sticky collapsible." />
+        <option name="homepage" value="https://tocn.vercel.app" />
+        <option name="urlTemplate" value="https://tocn.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-tokenui" />
+        <option name="name" value="Tokenui" />
+        <option name="namespace" value="@tokenui" />
+        <option name="baseUrl" value="https://www.tokenui.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautiful, interactive documentation components for your design tokens following industry standards." />
+        <option name="homepage" value="https://www.tokenui.dev" />
+        <option name="urlTemplate" value="https://www.tokenui.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-tool-ui" />
+        <option name="name" value="Tool-ui" />
+        <option name="namespace" value="@tool-ui" />
+        <option name="baseUrl" value="https://www.tool-ui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Open source React components for rendering AI tool call widgets and rich assistant outputs." />
+        <option name="homepage" value="https://www.tool-ui.com" />
+        <option name="urlTemplate" value="https://www.tool-ui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-tour" />
+        <option name="name" value="Tour" />
+        <option name="namespace" value="@tour" />
+        <option name="baseUrl" value="https://onboarding-tour.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A component for building onboarding tours. Designed to integrate with shadcn/ui." />
+        <option name="homepage" value="https://onboarding-tour.vercel.app" />
+        <option name="urlTemplate" value="https://onboarding-tour.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-trophy-ui" />
+        <option name="name" value="Trophy-ui" />
+        <option name="namespace" value="@trophy-ui" />
+        <option name="baseUrl" value="https://ui.trophy.so/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Open-source gamification UI components for streaks, achievements, leaderboards, points, and more. Built on shadcn/ui and Tailwind CSS." />
+        <option name="homepage" value="https://ui.trophy.so" />
+        <option name="urlTemplate" value="https://ui.trophy.so/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-turbopills-ui" />
+        <option name="name" value="Turbopills-ui" />
+        <option name="namespace" value="@turbopills-ui" />
+        <option name="baseUrl" value="https://ui.turbopills.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautiful, accessible, and customizable React components for your telehealth applications." />
+        <option name="homepage" value="https://www.turbopills.com/ui/docs" />
+        <option name="urlTemplate" value="https://ui.turbopills.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-typedora-ui" />
+        <option name="name" value="Typedora-ui" />
+        <option name="namespace" value="@typedora-ui" />
+        <option name="baseUrl" value="https://typedora-ui.netlify.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Typedora UI is a next-generation extension layer for shadcn/ui, designed to bring full type-safety to your UI components." />
+        <option name="homepage" value="https://typedora-ui.netlify.app" />
+        <option name="urlTemplate" value="https://typedora-ui.netlify.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-ui-layouts" />
+        <option name="name" value="Ui-layouts" />
+        <option name="namespace" value="@ui-layouts" />
+        <option name="baseUrl" value="https://ui-layouts.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="UI Layouts offers components, effects, design tools, and ready-made blocks that make building modern interfaces more efficient—built with React, Next.js, Tailwind CSS, and shadcn/ui." />
+        <option name="homepage" value="https://ui-layouts.com/" />
+        <option name="urlTemplate" value="https://ui-layouts.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-uicapsule" />
+        <option name="name" value="Uicapsule" />
+        <option name="namespace" value="@uicapsule" />
+        <option name="baseUrl" value="https://uicapsule.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A curated collection of components that spark joy. Featuring interactive concepts, design experiments, and components in the intersection of AI/UI." />
+        <option name="homepage" value="https://uicapsule.com" />
+        <option name="urlTemplate" value="https://uicapsule.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-uitripled" />
+        <option name="name" value="Uitripled" />
+        <option name="namespace" value="@uitripled" />
+        <option name="baseUrl" value="https://ui.tripled.work/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="An open-source, Production-ready UI components and blocks powered by shadcn/ui and Framer Motion" />
+        <option name="homepage" value="https://ui.tripled.work" />
+        <option name="urlTemplate" value="https://ui.tripled.work/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-unlumen-ui" />
+        <option name="name" value="Unlumen-ui" />
+        <option name="namespace" value="@unlumen-ui" />
+        <option name="baseUrl" value="https://ui.unlumen.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Primitives and components with serious attention to animation and design. Copy, own, ship." />
+        <option name="homepage" value="https://ui.unlumen.com" />
+        <option name="urlTemplate" value="https://ui.unlumen.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-untld" />
+        <option name="name" value="Untld" />
+        <option name="namespace" value="@untld" />
+        <option name="baseUrl" value="https://ui.untldlabs.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A set of beautifully designed components for modern web applications." />
+        <option name="homepage" value="https://ui.untldlabs.com" />
+        <option name="urlTemplate" value="https://ui.untldlabs.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-uselayouts" />
+        <option name="name" value="Uselayouts" />
+        <option name="namespace" value="@uselayouts" />
+        <option name="baseUrl" value="https://uselayouts.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of premium animated React components and micro-interactions built with Motion for building fluid, professional interfaces." />
+        <option name="homepage" value="https://uselayouts.com" />
+        <option name="urlTemplate" value="https://uselayouts.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-uui" />
+        <option name="name" value="Uui" />
+        <option name="namespace" value="@uui" />
+        <option name="baseUrl" value="https://uui.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Inspiration for UI Interfaces. Discover UI ideas, micro-interactions, and components drawn from real products." />
+        <option name="homepage" value="https://uui.app" />
+        <option name="urlTemplate" value="https://uui.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-utilcn" />
+        <option name="name" value="Utilcn" />
+        <option name="namespace" value="@utilcn" />
+        <option name="baseUrl" value="https://utilcn.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Fullstack registry items to start those big features. Utilcn has ChatGPT Apps, file uploading (with progress bars) and downloading, and a way to make your env vars typesafe on the backend." />
+        <option name="homepage" value="https://utilcn.dev" />
+        <option name="urlTemplate" value="https://utilcn.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-w3-kit" />
+        <option name="name" value="W3-kit" />
+        <option name="namespace" value="@w3-kit" />
+        <option name="baseUrl" value="https://w3-kit.com/registry" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Web3 UI components for blockchain dApps. Includes wallet connection, token swaps, NFT cards, staking interfaces, and 20+ more crypto components." />
+        <option name="homepage" value="https://w3-kit.com" />
+        <option name="urlTemplate" value="https://w3-kit.com/registry/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-wa-ui" />
+        <option name="name" value="Wa-ui" />
+        <option name="namespace" value="@wa-ui" />
+        <option name="baseUrl" value="https://ui.meta-cloud-api.site/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Production-ready WhatsApp Web UI components built on WDS design tokens with Tailwind CSS v4 and @base-ui/react." />
+        <option name="homepage" value="https://ui.meta-cloud-api.site" />
+        <option name="urlTemplate" value="https://ui.meta-cloud-api.site/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-wandry-ui" />
+        <option name="name" value="Wandry-ui" />
+        <option name="namespace" value="@wandry-ui" />
+        <option name="baseUrl" value="https://ui.wandry.com.ua/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A set of open source fully controlled React Inertia form elements" />
+        <option name="homepage" value="http://ui.wandry.com.ua/" />
+        <option name="urlTemplate" value="https://ui.wandry.com.ua/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-washiveil" />
+        <option name="name" value="Washiveil" />
+        <option name="namespace" value="@washiveil" />
+        <option name="baseUrl" value="https://washiveil.alexchih.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Washi at the ground, veils above, three lights beneath. A design system with Chinese &amp; Japanese typography considered from the start." />
+        <option name="homepage" value="https://washiveil.alexchih.com" />
+        <option name="urlTemplate" value="https://washiveil.alexchih.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-waves-cn" />
+        <option name="name" value="Waves-cn" />
+        <option name="namespace" value="@waves-cn" />
+        <option name="baseUrl" value="https://waves-cn.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of wave players and waveform components built with wavesurfer.js and shadcn/ui." />
+        <option name="homepage" value="https://waves-cn.vercel.app" />
+        <option name="urlTemplate" value="https://waves-cn.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-wds" />
+        <option name="name" value="Wds" />
+        <option name="namespace" value="@wds" />
+        <option name="baseUrl" value="https://wds-shadcn-registry.netlify.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A collection of accessible components built for use with Shadcn." />
+        <option name="homepage" value="https://wds-shadcn-registry.netlify.app/" />
+        <option name="urlTemplate" value="https://wds-shadcn-registry.netlify.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-wensity" />
+        <option name="name" value="Wensity" />
+        <option name="namespace" value="@wensity" />
+        <option name="baseUrl" value="https://raw.githubusercontent.com/ksparth12/wensity-shadcn-registry/main" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Motion-rich React components for AI interfaces, SaaS blocks, and cinematic interactions. Free Wensity components only." />
+        <option name="homepage" value="https://wensity.com" />
+        <option name="urlTemplate" value="https://raw.githubusercontent.com/ksparth12/wensity-shadcn-registry/main/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-wigggle-ui" />
+        <option name="name" value="Wigggle-ui" />
+        <option name="namespace" value="@wigggle-ui" />
+        <option name="baseUrl" value="https://wigggle-ui.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A beautiful collection of copy-and-paste widgets for your next project." />
+        <option name="homepage" value="https://wigggle-ui.vercel.app" />
+        <option name="urlTemplate" value="https://wigggle-ui.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-heatmap" />
+        <option name="name" value="Heatmap" />
+        <option name="namespace" value="@heatmap" />
+        <option name="baseUrl" value="https://shadcn-heatmap.pages.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautiful, accessible heatmap components for React: GitHub-style calendar, weekday x hour matrix, date x hour, and status timeline. Built with shadcn/ui conventions." />
+        <option name="homepage" value="https://shadcn-heatmap.pages.dev" />
+        <option name="urlTemplate" value="https://shadcn-heatmap.pages.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-xcn" />
+        <option name="name" value="Xcn" />
+        <option name="namespace" value="@xcn" />
+        <option name="baseUrl" value="https://ui.radiumcoders.com/r/xcn" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Hand-crafted, beautiful, and minimal UI components built with Tailwind CSS and Motion." />
+        <option name="homepage" value="https://ui.radiumcoders.com" />
+        <option name="urlTemplate" value="https://ui.radiumcoders.com/r/xcn/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-saaskit" />
+        <option name="name" value="Saaskit" />
+        <option name="namespace" value="@saaskit" />
+        <option name="baseUrl" value="https://saaskit-theta.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="10 essential shadcn/ui components for B2B SaaS: Pricing, Billing, Usage, and Onboarding. Minimalist Soft Brutalist design." />
+        <option name="homepage" value="https://saaskit-theta.vercel.app" />
+        <option name="urlTemplate" value="https://saaskit-theta.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-zippystarter" />
+        <option name="name" value="Zippystarter" />
+        <option name="namespace" value="@zippystarter" />
+        <option name="baseUrl" value="https://zippystarter.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Expertly crafted blocks, components &amp; themes for shadcn/ui." />
+        <option name="homepage" value="https://zippystarter.com" />
+        <option name="urlTemplate" value="https://zippystarter.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-kaui" />
+        <option name="name" value="Kaui" />
+        <option name="namespace" value="@kaui" />
+        <option name="baseUrl" value="https://kaui-shadcn-registry.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Personal well crafted components for Shadcn ui" />
+        <option name="homepage" value="https://kaui-shadcn-registry.vercel.app" />
+        <option name="urlTemplate" value="https://kaui-shadcn-registry.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-uiable" />
+        <option name="name" value="Uiable" />
+        <option name="namespace" value="@uiable" />
+        <option name="baseUrl" value="https://uiable.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Free, open-source UI component library built with Next.js, React 19, Tailwind CSS v4, and shadcn/ui — beautifully designed components you can copy, customize, and make your own." />
+        <option name="homepage" value="https://uiable.com" />
+        <option name="urlTemplate" value="https://uiable.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-velobits" />
+        <option name="name" value="Velobits" />
+        <option name="namespace" value="@velobits" />
+        <option name="baseUrl" value="https://ui.velobits.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="An open source collection of accessible, contrast-gated React components on a warm neutral palette and a two-tier glass material — the VeloBits design system, authored once and shipped both as an npm package and as this registry." />
+        <option name="homepage" value="https://ui.velobits.dev" />
+        <option name="urlTemplate" value="https://ui.velobits.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-vue-bits" />
+        <option name="name" value="Vue-bits" />
+        <option name="namespace" value="@vue-bits" />
+        <option name="baseUrl" value="https://vue-bits.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="An open source collection of high quality, animated, interactive &amp; fully customizable Vue components for building stunning, memorable user interfaces." />
+        <option name="homepage" value="https://vue-bits.dev" />
+        <option name="urlTemplate" value="https://vue-bits.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-svelte-bits" />
+        <option name="name" value="Svelte-bits" />
+        <option name="namespace" value="@svelte-bits" />
+        <option name="baseUrl" value="https://sveltebits.xyz/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="An open source collection of high quality, animated, interactive &amp; fully customizable Svelte components for building stunning, memorable user interfaces." />
+        <option name="homepage" value="https://sveltebits.xyz" />
+        <option name="urlTemplate" value="https://sveltebits.xyz/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-aniui" />
+        <option name="name" value="Aniui" />
+        <option name="namespace" value="@aniui" />
+        <option name="baseUrl" value="https://aniui.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Beautiful, accessible React Native components (Uniwind or NativeWind) — copy, paste, own the code. 93 components plus pre-built screen blocks, installable with the shadcn CLI." />
+        <option name="homepage" value="https://aniui.dev" />
+        <option name="urlTemplate" value="https://aniui.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-threecn" />
+        <option name="name" value="Threecn" />
+        <option name="namespace" value="@threecn" />
+        <option name="baseUrl" value="https://threecn.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="3D scenes for shadcn/ui. Theme-aware React Three Fiber components, one command away." />
+        <option name="homepage" value="https://threecn.dev" />
+        <option name="urlTemplate" value="https://threecn.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-vllnt-ui" />
+        <option name="name" value="Vllnt-ui" />
+        <option name="namespace" value="@vllnt-ui" />
+        <option name="baseUrl" value="https://ui.vllnt.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="VLLNT UI — agent-first React components for AI-native products, from UI primitives to finance and ops domains. Accessible, Radix + Tailwind, you own the code." />
+        <option name="homepage" value="https://ui.vllnt.com" />
+        <option name="urlTemplate" value="https://ui.vllnt.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-grainly-icons" />
+        <option name="name" value="Grainly-icons" />
+        <option name="namespace" value="@grainly-icons" />
+        <option name="baseUrl" value="https://grainlyicons.abhii.space/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Animated grainy icons" />
+        <option name="homepage" value="https://grainlyicons.abhii.space" />
+        <option name="urlTemplate" value="https://grainlyicons.abhii.space/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-shadcnloaders" />
+        <option name="name" value="Shadcnloaders" />
+        <option name="namespace" value="@shadcnloaders" />
+        <option name="baseUrl" value="https://shadcn-loaders.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A public registry of shadcn-inspired animated loaders and loading states." />
+        <option name="homepage" value="https://shadcn-loaders.vercel.app" />
+        <option name="urlTemplate" value="https://shadcn-loaders.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-shadcn-dashboard" />
+        <option name="name" value="Shadcn-dashboard" />
+        <option name="namespace" value="@shadcn-dashboard" />
+        <option name="baseUrl" value="https://shadcndashboard.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Shadcn Dashboard is a collection of modern, production-ready dashboard layouts, components, and UI patterns built on top of shadcn/ui and Tailwind CSS. It’s designed to help developers build clean, scalable, and data-driven dashboards faster—without compromising on performance, accessibility, or customization." />
+        <option name="homepage" value="https://shadcndashboard.dev" />
+        <option name="urlTemplate" value="https://shadcndashboard.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-usva" />
+        <option name="name" value="Usva" />
+        <option name="namespace" value="@usva" />
+        <option name="baseUrl" value="https://usva.build/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A React design language in three themes, where kajo is atmospheric and dark, sisu is dense and quick, and savi is the light ground. One token vocabulary underneath, including WebGL atmospheres that honour reduced-motion. Every component installs from npm or copies in from this registry." />
+        <option name="homepage" value="https://usva.build" />
+        <option name="urlTemplate" value="https://usva.build/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-atelier" />
+        <option name="name" value="Atelier" />
+        <option name="namespace" value="@atelier" />
+        <option name="baseUrl" value="https://www.atelier-ui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A WebGL and Motion system for React that runs many effects on one shared canvas. Shader, cursor, scroll and text effects, 3D galleries, plus page transitions for Next.js. Built with Three.js, React Three Fiber, Motion, and Lenis smooth scroll." />
+        <option name="homepage" value="https://www.atelier-ui.com" />
+        <option name="urlTemplate" value="https://www.atelier-ui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-mediadrop" />
+        <option name="name" value="Mediadrop" />
+        <option name="namespace" value="@mediadrop" />
+        <option name="baseUrl" value="https://www.mediadrop.dev/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Drag-and-drop file upload blocks for React built on react-mediadrop — dropzone, avatar uploader, multi-file upload form, and direct-to-S3 upload." />
+        <option name="homepage" value="https://www.mediadrop.dev" />
+        <option name="urlTemplate" value="https://www.mediadrop.dev/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-ai2" />
+        <option name="name" value="Ai2" />
+        <option name="namespace" value="@ai2" />
+        <option name="baseUrl" value="https://ai2.design/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Agent-native design system for the shadcn CLI: 51 base components with a full variant, tone and size matrix on an OKLCH token layer, plus 307 styled variations. MIT." />
+        <option name="homepage" value="https://ai2.design" />
+        <option name="urlTemplate" value="https://ai2.design/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-whiskeyjack" />
+        <option name="name" value="Whiskeyjack" />
+        <option name="namespace" value="@whiskeyjack" />
+        <option name="baseUrl" value="https://whiskeyjack.net/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="A Tauri-first design system: thumb-first components with Metro-style pivot navigation, frosted bottom nav, and tap-again confirmations, on a CSS-variable token pipeline. Hardened across nine shipping apps before extraction." />
+        <option name="homepage" value="https://whiskeyjack.net" />
+        <option name="urlTemplate" value="https://whiskeyjack.net/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-atroui" />
+        <option name="name" value="Atroui" />
+        <option name="namespace" value="@atroui" />
+        <option name="baseUrl" value="https://www.atroui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Dark-first React / Next.js components and marketing blocks. Install with the shadcn CLI and own the source." />
+        <option name="homepage" value="https://www.atroui.com" />
+        <option name="urlTemplate" value="https://www.atroui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-knock-codes" />
+        <option name="name" value="Knock-codes" />
+        <option name="namespace" value="@knock-codes" />
+        <option name="baseUrl" value="https://knock.codes/r/react" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Copy-paste, session-gated access blocks for React — PIN/Knock Code unlock screens, protected routes/layouts/modals, a headless useKnockCodes hook, and full-page templates." />
+        <option name="homepage" value="https://knock.codes" />
+        <option name="urlTemplate" value="https://knock.codes/r/react/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-remotionui" />
+        <option name="name" value="Remotionui" />
+        <option name="namespace" value="@remotionui" />
+        <option name="baseUrl" value="https://remotionui.com/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="Copy-paste motion components for Remotion video projects - 200 captions, charts, transitions, backgrounds, and full compositions." />
+        <option name="homepage" value="https://remotionui.com" />
+        <option name="urlTemplate" value="https://remotionui.com/r/{name}.json" />
+      </RegistryConfigState>
+      <RegistryConfigState>
+        <option name="id" value="central-vernostudio" />
+        <option name="name" value="Vernostudio" />
+        <option name="namespace" value="@vernostudio" />
+        <option name="baseUrl" value="https://verno-studio.vercel.app/r" />
+        <option name="stylePath" value="/{name}.json" />
+        <option name="type" value="community" />
+        <option name="enabled" value="false" />
+        <option name="description" value="The full OKLCH scale plus every variable shadcn components read, so anything you install lands on the same tokens instead of its own colors." />
+        <option name="homepage" value="https://verno-studio.vercel.app/components" />
+        <option name="urlTemplate" value="https://verno-studio.vercel.app/r/{name}.json" />
+      </RegistryConfigState>
+    </registryConfigs>
+  </component>
+</project>

--- a/.idea/braccato.iml
+++ b/.idea/braccato.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/braccato.iml" filepath="$PROJECT_DIR$/.idea/braccato.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/demo/api.js
+++ b/demo/api.js
@@ -229,6 +229,11 @@ export const CLASS_NAMES = [
   { constant: "CURRENT_LYRICS_CLASS", value: "blyrics--active", summary: "The line the song is on right now." },
   { constant: "WORD_CLASS", value: "blyrics--word", summary: "One word, and the unit the sweep animates." },
   {
+    constant: "HIGHLIGHT_CLIP_CLASS",
+    value: "blyrics-highlight-clip",
+    summary: "Selects the opt-in solid-color highlight surface on a word.",
+  },
+  {
     constant: "BACKGROUND_LYRIC_CLASS",
     value: "blyrics-background-lyric",
     summary: "A background vocal, sung over the line it answers.",
@@ -258,6 +263,12 @@ export const CLASS_NAMES = [
 // `rebuilds` marks the ones the lines are built out of rather than ticked against, which is why
 // writing one of those reports braccato:lyrics-loaded again.
 export const THEME_SETTINGS = [
+  {
+    key: "blyrics-highlight-render-mode",
+    fallback: "gradient",
+    rebuilds: true,
+    summary: "Uses the compatible gradient swipe, or the experimental lower-cost clip reveal.",
+  },
   {
     key: "blyrics-target-scroll-pos-ratio",
     fallback: "0.37",

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -1639,9 +1639,9 @@ braccato-lyrics {
 
    Two selectors because there are two targets. A word short enough to stay whole is animated
    through its own `::after`; one past `blyrics-long-word-wrap-threshold` is split, and the sweep
-   moves to the `.blyrics-word-highlight` span inside it. */
+   moves to the `.blyrics-word-highlight` span before it. */
 .blyrics--word:not([data-long-word])::after,
-.blyrics--word:not([data-long-word]) .blyrics-word-highlight {
+.blyrics-word-highlight:not([data-long-word]) {
 	--blyrics-glow-color: transparent;
 }
 

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -50,6 +50,9 @@ const AUDIO_EXTENSIONS = /\.(mp3|wav|ogg|oga|m4a|aac|flac|opus|weba|webm)$/i;
 // Object URLs are not in the list: those are minted from a picked file rather than typed.
 const AUDIO_URL_SCHEMES = new Set(["http:", "https:"]);
 const PANEL_OPEN_WIDTH = "(min-width: 1080px)";
+const BENCHMARK_MODE = new URLSearchParams(location.search).get("benchmark") === "1";
+const BENCHMARK_START_S = 8;
+const BENCHMARK_END_S = 13;
 
 const view = document.querySelector(TAG_NAME);
 const player = document.getElementById("player");
@@ -450,7 +453,7 @@ function builtInLyrics() {
 
 const DEFAULTS = {
   songId: SONGS[0].id,
-  timing: "syllables",
+  timing: "lines",
   themeId: THEMES[0].id,
   offsetMs: 0,
   passiveScroll: false,
@@ -506,6 +509,7 @@ function readStateFromUrl() {
  */
 function writeStateToUrl() {
   const params = new URLSearchParams();
+  if (BENCHMARK_MODE) params.set("benchmark", "1");
   if (state.audio === null && state.songId !== DEFAULTS.songId) params.set("song", state.songId);
   if (state.importedLyrics === null && state.timing !== DEFAULTS.timing) params.set("lines", state.timing);
   if (state.themeId !== null && state.themeId !== DEFAULTS.themeId) params.set("theme", state.themeId);
@@ -621,7 +625,9 @@ function paintControls() {
 
   timingHint.textContent =
     state.importedLyrics === null
-      ? TIMINGS[state.timing].hint
+      ? state.timing === "syllables" && scoreFor(state.songId).every(line => line.parts === undefined)
+        ? "This source only supplied line timestamps, so there is no syllable timing to preserve."
+        : TIMINGS[state.timing].hint
       : `${state.importedName} is what the element is holding. Pick one of these to put the built-in song back.`;
 
   nowPlaying.textContent = state.audio?.label ?? SONGS.find(candidate => candidate.id === state.songId).title;
@@ -1088,6 +1094,25 @@ function wireTransport() {
   });
 }
 
+// A muted five-second loop for external profilers. It is URL-driven so every run can start from a
+// fresh document with the same song segment and no automation click or seek in the measurement.
+function startBenchmarkIfRequested() {
+  if (!BENCHMARK_MODE) return;
+
+  document.documentElement.dataset.benchmark = "on";
+  player.muted = true;
+  player.addEventListener("timeupdate", () => {
+    if (player.currentTime >= BENCHMARK_END_S) player.currentTime = BENCHMARK_START_S;
+  });
+
+  const start = () => {
+    player.currentTime = BENCHMARK_START_S;
+    startPlayback();
+  };
+  if (player.readyState >= HTMLMediaElement.HAVE_CURRENT_DATA) start();
+  else player.addEventListener("loadeddata", start, { once: true });
+}
+
 // -- Autoscroll --------------------------------------------
 
 /**
@@ -1327,6 +1352,7 @@ async function boot() {
   wireDropAndPaste();
   wireTransport();
   paintTransport();
+  startBenchmarkIfRequested();
 
   // The element never tells its renderer that someone scrolled the view, so autoscroll would keep
   // pulling the song back under anyone reading ahead. `renderer` is published for reaching past the

--- a/demo/song.js
+++ b/demo/song.js
@@ -478,11 +478,65 @@ const THE_STEPS = [
   { chord: "Dm", instrumental: true },
 ];
 
+// The line-synchronised LRC returned by lyrics.api.dacubeking.com for YouTube video 7M95h7zQU3k.
+// It has no word timing, so these stay as lines rather than inventing richer timing than the source
+// supplied. The final line runs to the duration sent with the request (3:32).
+const OMAKE_PFADLIB_LINES = [
+  [1880, "Omake-Pfadlib"],
+  [8870, "泽野弘之"],
+  [13120, "进击的巨人第六话 儿时的回忆 结尾钢琴曲"],
+  [28130, "从天而降的噩梦，突如其来的歹人，让三笠失去了家人。"],
+  [43880, "面对即将被卖掉的厄运。"],
+  [51950, "是艾伦从歹人手中下了三笠。也是他教会三笠【战斗】"],
+  [74460, "然而，父母在途中被歹人杀害，无家可归是直面三笠的一个残忍的事实。"],
+  [92420, "耶格尔医生……"],
+  [95670, "我……从这里开始，究竟该朝哪个方向走回去才好？"],
+  [106220, "好冷……"],
+  [109270, "我已经……"],
+  [111270, "没有回去的地方了……"],
+  [115470, "……"],
+  [117820, "这个送给你。"],
+  [122750, "这样就暖和些了吧。"],
+  [126700, "……"],
+  [130050, "很温暖……"],
+  [134560, "三笠，到我们家来一起生活吧。"],
+  [138660, "经历了那么多痛苦的事情，"],
+  [142260, "你现在需要充分的修养。"],
+  [145610, "……"],
+  [146460, "怎么了？"],
+  [148460, "来呀，快点回去吧。"],
+  [152020, "回我们的家。"],
+  [154220, "……"],
+  [157920, "回家……"],
+  [166720, "只有胜者才被容许生存的，这个残酷的世界。"],
+  [171970, "撤退，阿克曼"],
+  [174070, "要登上墙壁了喔。"],
+  [176870, "我去支援前卫部队撤退"],
+  [178720, "什……喂，阿克曼!"],
+  [183020, "但是对我而言，这个世界上还有我可以回去的地方。"],
+  [190320, "艾伦，只要有你在，"],
+  [193220, "我就无所不能。"],
+];
+
+const OMAKE_PFADLIB_CHORDS = ["Dm", "Bb", "F", "C"];
+const OMAKE_PFADLIB_BARS = Array.from({ length: 53 }, (_, index) => ({
+  chord: OMAKE_PFADLIB_CHORDS[index % OMAKE_PFADLIB_CHORDS.length],
+  instrumental: true,
+}));
+
 /**
  * What the picker shows and what the audio generator walks. `beatMs` is the only tempo there is: a
  * bar is four beats, and every syllable duration below is measured in them.
  */
 export const SONGS = [
+  {
+    id: "omake-pfadlib",
+    title: "Omake-Pfadlib",
+    summary: "The line-synced Kugou fixture returned for 7M95h7zQU3k, with its original 3:32 timeline.",
+    beatMs: 1000,
+    bars: OMAKE_PFADLIB_BARS,
+    timedLines: OMAKE_PFADLIB_LINES,
+  },
   {
     id: "kettle",
     title: "Kettle",
@@ -548,11 +602,21 @@ export function buildScore(songId) {
   const bars = [];
   let barStartMs = 0;
 
+  if (song.timedLines !== undefined) {
+    for (let index = 0; index < song.timedLines.length; index++) {
+      const [startTimeMs, words] = song.timedLines[index];
+      const nextStartMs = song.timedLines[index + 1]?.[0] ?? song.bars.length * barMs;
+      lyrics.push({ startTimeMs, durationMs: nextStartMs - startTimeMs, words });
+    }
+  }
+
   for (const bar of song.bars) {
     bars.push({ startMs: barStartMs, durationMs: barMs, chord: bar.chord });
 
     if (bar.instrumental) {
-      lyrics.push({ startTimeMs: barStartMs, durationMs: barMs, words: "", isInstrumental: true });
+      if (song.timedLines === undefined) {
+        lyrics.push({ startTimeMs: barStartMs, durationMs: barMs, words: "", isInstrumental: true });
+      }
       barStartMs += barMs;
       continue;
     }

--- a/demo/theme-sustain.css
+++ b/demo/theme-sustain.css
@@ -172,7 +172,7 @@
   --blyrics-glow-color: color(display-p3 1 1 1 / 0.0001);
 }
 
-.blyrics--word[data-long-word]::after, .blyrics--word[data-long-word] > .blyrics-word-highlight {
+.blyrics--word[data-long-word]::after, .blyrics-word-highlight[data-long-word] {
   --blyrics-glow-color: color(display-p3 1 1 1 / 1);
 }
 

--- a/demo/themes.js
+++ b/demo/themes.js
@@ -11,6 +11,43 @@
 
 import sustain from "./theme-sustain.css?raw";
 
+function performanceTheme(renderMode, highlightEnabled) {
+  return `/* Deterministic renderer benchmark. Keep the song, timing, seek point, viewport, and browser
+   refresh rate fixed when comparing these three themes. */
+/* blyrics-highlight-render-mode = ${renderMode}; */
+
+.blyrics-container {
+	--blyrics-animate-line-scale: 0;
+	--blyrics-animate-word-wobble: 0;
+	--blyrics-animate-highlight-swipe: ${highlightEnabled ? 1 : 0};
+	--blyrics-animate-highlight-glow: ${highlightEnabled ? 1 : 0};
+	--blyrics-animate-highlight-fade: ${highlightEnabled ? 1 : 0};
+	--blyrics-animate-scroll: 1;
+	--blyrics-animate-instrumental: 0;
+	--blyrics-scale: 1;
+	--blyrics-active-scale: 1;
+	--blyrics-font-weight: 700;
+	--blyrics-lyric-active-color: oklch(0.91 0.1 84);
+	--blyrics-lyric-inactive-color: oklch(0.91 0.1 84 / 0.24);
+	--blyrics-glow-color: oklch(0.96 0.08 84 / 0.9);
+}
+
+${
+  highlightEnabled
+    ? ""
+    : `.blyrics--word::after,
+.blyrics-word-highlight {
+	display: none;
+}
+
+.blyrics--active,
+.blyrics--active .blyrics--word {
+	color: var(--blyrics-lyric-active-color);
+}
+`
+}`;
+}
+
 export const THEMES = [
   {
     id: "amber",
@@ -96,5 +133,23 @@ export const THEMES = [
 	--blyrics-lyric-active-color: oklch(0.93 0.012 96 / 0.7);
 }
 `,
+  },
+  {
+    id: "perf-gradient",
+    title: "Perf: Gradient",
+    summary: "A/B control: the existing gradient swipe with unrelated renderer motion disabled.",
+    css: performanceTheme("gradient", true),
+  },
+  {
+    id: "perf-clip",
+    title: "Perf: Clip",
+    summary: "Candidate: a solid text duplicate revealed with a direction-aware inset clip.",
+    css: performanceTheme("clip", true),
+  },
+  {
+    id: "perf-off",
+    title: "Perf: Off",
+    summary: "Lower-bound control: scroll remains, while the duplicate highlight surface is hidden.",
+    css: performanceTheme("gradient", false),
   },
 ];

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"format": "biome format --write .",
 		"release": "bash scripts/release.sh",
 		"package": "tsx tooling/build-package.ts",
+		"package:watch": "tsx tooling/watch-package.ts",
 		"selfcheck": "tsx tooling/run-selfchecks.ts"
 	},
 	"devDependencies": {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -158,6 +158,11 @@ while a property said otherwise would leave the module with two answers and no r
 `parseThemeConfig` is published on `@braccato/core/themeSettings` for reading the settings out of a
 stylesheet somewhere no renderer is running.
 
+The word highlight defaults to the compatible gradient renderer. A theme can opt into the
+solid-color clipped renderer with `/* blyrics-highlight-render-mode = clip; */`. Changing this
+setting rebuilds the lyrics; swipe duration, easing, early setup, fades, and glow timing stay the
+same. Unknown values fall back to `gradient`.
+
 ### Custom properties
 
 The ones a theme reaches for first. `variables.css` declares the rest.
@@ -190,6 +195,7 @@ refactor. Import them from `@braccato/core/constants` instead of typing them out
 | `LINE_CLASS`              | `blyrics--line`             | One line, carrying its own `dir="auto"`.                     |
 | `CURRENT_LYRICS_CLASS`    | `blyrics--active`           | The line the song is on right now.                           |
 | `WORD_CLASS`              | `blyrics--word`             | One word, and the unit the sweep animates.                   |
+| `HIGHLIGHT_CLIP_CLASS`    | `blyrics-highlight-clip`    | The opt-in solid-color highlight surface.                    |
 | `BACKGROUND_LYRIC_CLASS`  | `blyrics-background-lyric`  | A background vocal, sung over the line it answers.           |
 | `USER_SCROLLING_CLASS`    | `blyrics-user-scrolling`    | Set while a reader has scrolled away and autoscroll waits.   |
 | `TRANSLATED_LYRICS_CLASS` | `blyrics--translated`       | A translation hung off a line that was already built.        |
@@ -298,6 +304,10 @@ Full documentation is at [braccato.boidu.dev](https://braccato.boidu.dev).
 The demo page lives at [`demo/`](https://github.com/better-lyrics/braccato/tree/master/demo) in the
 repository and runs against the emitted package, with a control for most of what is above. Clone the
 repository and run `pnpm -C demo dev`, then open `http://localhost:5173/`.
+
+For renderer profiling, select **Perf: Gradient**, **Perf: Clip**, or **Perf: Off** in the Theme
+panel. Adding `benchmark=1` to the URL mutes playback and loops the same five-second segment, so an
+external profiler can compare fresh documents without automating the transport.
 
 ## Licence
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -46,6 +46,7 @@
   },
   "scripts": {
     "build": "tsx ../../tooling/build-package.ts",
+    "dev": "tsx ../../tooling/watch-package.ts",
     "typecheck": "tsc --noEmit",
     "selfcheck": "tsx ../../tooling/run-selfchecks.ts",
     "clean": "rm -rf dist"

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -33,6 +33,7 @@ export const BACKGROUND_LINE_CLASS = "blyrics-background-line" as const;
 export const WORD_GROUP_CLASS = "blyrics-word-group" as const;
 export const LONG_WORD_GROUP_CLASS = "blyrics-word-group-long" as const;
 export const WORD_HIGHLIGHT_CLASS = "blyrics-word-highlight" as const;
+export const WORD_WITH_HIGHLIGHT_CLASS = "blyrics-word-with-highlight" as const;
 export const HIGHLIGHT_CLIP_CLASS = "blyrics-highlight-clip" as const;
 export const LINE_SYNCED_WORD_CLASS = "blyrics-line-synced-word" as const;
 export const BIDI_RUN_CLASS = "blyrics-bidi-run" as const;

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -33,6 +33,7 @@ export const BACKGROUND_LINE_CLASS = "blyrics-background-line" as const;
 export const WORD_GROUP_CLASS = "blyrics-word-group" as const;
 export const LONG_WORD_GROUP_CLASS = "blyrics-word-group-long" as const;
 export const WORD_HIGHLIGHT_CLASS = "blyrics-word-highlight" as const;
+export const HIGHLIGHT_CLIP_CLASS = "blyrics-highlight-clip" as const;
 export const LINE_SYNCED_WORD_CLASS = "blyrics-line-synced-word" as const;
 export const BIDI_RUN_CLASS = "blyrics-bidi-run" as const;
 export const BIDI_SENSITIVE_CLASS = "blyrics-bidi-sensitive" as const;

--- a/packages/core/src/engine.selfcheck.ts
+++ b/packages/core/src/engine.selfcheck.ts
@@ -601,7 +601,7 @@ assert.equal(
 const clipFixture = renderHighlightFixture("clip", HIGHLIGHT_FIXTURE_LYRICS);
 const clipWords = renderedWords(clipFixture.mount);
 const ltrClipSwipe = clipWords[0]?.animations[0];
-const wrappedClipHighlight = collectTree(clipWords[1]).find(node => node.classList.contains(WORD_HIGHLIGHT_CLASS));
+const wrappedClipHighlight = collectTree(clipFixture.mount).find(node => node.classList.contains(WORD_HIGHLIGHT_CLASS));
 const rtlClipSwipe = clipWords[2]?.animations[0];
 
 assert.ok(
@@ -615,7 +615,7 @@ assert.deepEqual(
 );
 assert.ok(
   wrappedClipHighlight,
-  "Given a word long enough to wrap, When it is rendered, Then it owns the nested highlight surface"
+  "Given a word long enough to wrap, When it is rendered, Then its group owns a highlight surface"
 );
 assert.deepEqual(
   wrappedClipHighlight?.animations[0]?.keyframes,

--- a/packages/core/src/engine.selfcheck.ts
+++ b/packages/core/src/engine.selfcheck.ts
@@ -1,5 +1,12 @@
 import { strict as assert } from "node:assert";
-import { LINE_CLASS, USER_SCROLLING_CLASS } from "./constants";
+import {
+  HIGHLIGHT_CLIP_CLASS,
+  LINE_CLASS,
+  RTL_CLASS,
+  USER_SCROLLING_CLASS,
+  WORD_CLASS,
+  WORD_HIGHLIGHT_CLASS,
+} from "./constants";
 import {
   type AnimationEngineInstance,
   clearLyrics,
@@ -17,6 +24,7 @@ import {
 } from "./engine";
 import { asDocument, asElement, collectTree, FakeDocument, type FakeNode } from "./selfcheck/fakeDom";
 import { asWindow, FakeMediaQueryList, FakeWindow, poisonAmbientGlobals } from "./selfcheck/fakeWindow";
+import { setThemeSettings } from "./themeSettings";
 import type { Lyric, LyricsRendererHost, TickOptions } from "./types";
 import { setLyrics } from "./view";
 
@@ -149,6 +157,15 @@ const FLOATING_STYLE: Record<string, string> = {
   [ANIMATE_SCROLL_PROPERTY]: "0",
 };
 
+const HIGHLIGHT_FIXTURE_STYLE: Record<string, string> = {
+  [ANIMATE_SCROLL_PROPERTY]: "0",
+  "--blyrics-animate-line-scale": "0",
+  "--blyrics-animate-word-wobble": "0",
+  "--blyrics-animate-highlight-glow": "0",
+};
+
+const HIGHLIGHT_RENDER_MODE_SETTING = "blyrics-highlight-render-mode";
+
 function newTickOptions(): TickOptions {
   return {
     eventCreationTime: -1,
@@ -190,6 +207,38 @@ function soleMediaQuery(fakeWindow: FakeWindow): FakeMediaQueryList {
     "Given an instance, When its window is read, Then it asked that window about exactly one media query"
   );
   return lists[0];
+}
+
+function renderedWords(mount: FakeNode): FakeNode[] {
+  return collectTree(mount).filter(node => node.classList.contains(WORD_CLASS));
+}
+
+function renderHighlightFixture(
+  mode: string | null,
+  lyrics: Lyric[],
+  styleOverrides: Record<string, string> = {}
+): {
+  engine: AnimationEngineInstance;
+  mount: FakeNode;
+} {
+  setThemeSettings(mode === null ? new Map() : new Map([[HIGHLIGHT_RENDER_MODE_SETTING, mode]]));
+
+  const fixtureDocument = new FakeDocument();
+  const fixtureWindow = new FakeWindow({ ...HIGHLIGHT_FIXTURE_STYLE, ...styleOverrides });
+  const fixtureEngine = createAnimationEngineInstance(
+    asDocument(fixtureDocument),
+    asWindow(fixtureWindow),
+    new FakeHost()
+  );
+  const fixtureMount = fixtureDocument.createElement("div");
+  setLyrics(fixtureEngine, asElement<HTMLElement>(fixtureMount), lyrics, { loaderVisible: false, noLyrics: false });
+  placeLines(fixtureEngine);
+  assert.equal(
+    tickView(fixtureEngine, PLAYBACK_TIME_S, resolveTickOptions(newTickOptions())),
+    "ok",
+    "Given a highlight fixture, When it ticks during the two-second setup lead, Then its animations are prepared"
+  );
+  return { engine: fixtureEngine, mount: fixtureMount };
 }
 
 // -- Two instances --------------------------------------------
@@ -459,6 +508,25 @@ assert.equal(
   "Given a document that disables scroll animation, When its view ticks, Then it promotes nothing"
 );
 
+const panelWillChangeWriteCounts = renderedLineElements(panelMount).map(
+  line => line.style.propertyWriteCounts["will-change"] ?? 0
+);
+const panelVisibleWillChangeElements = panelEngine.visibleWillChangeElements;
+
+tickView(panelEngine, PLAYBACK_TIME_S, resolveTickOptions(newTickOptions()));
+
+assert.deepEqual(
+  renderedLineElements(panelMount).map(line => line.style.propertyWriteCounts["will-change"] ?? 0),
+  panelWillChangeWriteCounts,
+  "Given the visible lines are already promoted, When another tick sees the same viewport, Then it does not rewrite will-change"
+);
+
+assert.equal(
+  panelEngine.visibleWillChangeElements,
+  panelVisibleWillChangeElements,
+  "Given the viewport inputs are unchanged, When another tick updates promotion, Then it reuses the visible set rather than scanning into a new one"
+);
+
 // -- A reduced motion change reaches one view --------------------------------------------
 
 assert.equal(
@@ -485,6 +553,162 @@ assert.notEqual(
   null,
   "Given a reduced motion change on one window, When the other view's settings are read, Then they survived"
 );
+
+// -- Gradient and clipped highlight surfaces --------------------------------------------
+
+const HIGHLIGHT_FIXTURE_LYRICS: Lyric[] = [
+  {
+    startTimeMs: 1000,
+    durationMs: 3000,
+    words: "Short extraordinarilylong שלום",
+    parts: [
+      { startTimeMs: 1000, durationMs: 800, words: "Short" },
+      { startTimeMs: 1800, durationMs: 1200, words: "extraordinarilylong" },
+      { startTimeMs: 3000, durationMs: 1000, words: "שלום" },
+    ],
+  },
+];
+
+const gradientFixture = renderHighlightFixture(null, HIGHLIGHT_FIXTURE_LYRICS);
+const gradientWords = renderedWords(gradientFixture.mount);
+const gradientSwipe = gradientWords[0]?.animations[0];
+assert.ok(gradientSwipe, "Given the default renderer mode, When a rich-synced word is prepared, Then it has a swipe");
+assert.equal(
+  gradientWords[0]?.classList.contains(HIGHLIGHT_CLIP_CLASS),
+  false,
+  "Given no render-mode setting, When a word is prepared, Then it keeps the published gradient surface"
+);
+assert.deepEqual(
+  gradientSwipe.keyframes,
+  [
+    { "--lyric-transition-amount-start": "-0.2", "--lyric-transition-amount-end": "-0.1" },
+    { "--lyric-transition-amount-start": "1.4", "--lyric-transition-amount-end": "1.5" },
+  ],
+  "Given the default renderer mode, When its swipe is read, Then the existing gradient custom-property keyframes are unchanged"
+);
+
+assert.equal(
+  setThemeSettings(new Map([[HIGHLIGHT_RENDER_MODE_SETTING, "clip"]])),
+  true,
+  "Given lyrics built for the gradient surface, When a theme opts into clipping, Then the host is told to rebuild them"
+);
+assert.equal(
+  setThemeSettings(new Map([[HIGHLIGHT_RENDER_MODE_SETTING, "clip"]])),
+  false,
+  "Given clipping is already selected, When the same theme is applied again, Then no redundant lyric rebuild is requested"
+);
+
+const clipFixture = renderHighlightFixture("clip", HIGHLIGHT_FIXTURE_LYRICS);
+const clipWords = renderedWords(clipFixture.mount);
+const ltrClipSwipe = clipWords[0]?.animations[0];
+const wrappedClipHighlight = collectTree(clipWords[1]).find(node => node.classList.contains(WORD_HIGHLIGHT_CLASS));
+const rtlClipSwipe = clipWords[2]?.animations[0];
+
+assert.ok(
+  clipWords.every(word => word.classList.contains(HIGHLIGHT_CLIP_CLASS)),
+  "Given clip mode, When rich-synced words are prepared, Then every word selects the solid-color surface"
+);
+assert.deepEqual(
+  ltrClipSwipe?.keyframes,
+  [{ clipPath: "inset(0 100% 0 0)" }, { clipPath: "inset(0 0 0 0)" }],
+  "Given a left-to-right word in clip mode, When its swipe is read, Then the reveal travels left to right"
+);
+assert.ok(
+  wrappedClipHighlight,
+  "Given a word long enough to wrap, When it is rendered, Then it owns the nested highlight surface"
+);
+assert.deepEqual(
+  wrappedClipHighlight?.animations[0]?.keyframes,
+  [{ clipPath: "inset(0 100% 0 0)" }, { clipPath: "inset(0 0 0 0)" }],
+  "Given a wrapped word in clip mode, When its swipe is read, Then the nested surface receives the clip animation"
+);
+assert.equal(
+  clipWords[2]?.classList.contains(RTL_CLASS),
+  true,
+  "Given right-to-left text, When its word is built, Then direction is available to the clip renderer"
+);
+assert.deepEqual(
+  rtlClipSwipe?.keyframes,
+  [{ clipPath: "inset(0 0 0 100%)" }, { clipPath: "inset(0 0 0 0)" }],
+  "Given a right-to-left word in clip mode, When its swipe is read, Then the reveal travels right to left"
+);
+assert.deepEqual(
+  [ltrClipSwipe?.currentTime, ltrClipSwipe?.options],
+  [gradientSwipe.currentTime, gradientSwipe.options],
+  "Given gradient and clip controls for the same word, When their timing is read, Then duration, easing, fill, and early current time are identical"
+);
+
+const lineSyncedClipFixture = renderHighlightFixture("clip", [
+  { startTimeMs: 1000, durationMs: 3000, words: "Whole line" },
+]);
+const lineSyncedWord = renderedWords(lineSyncedClipFixture.mount)[0];
+assert.deepEqual(
+  lineSyncedWord?.animations[0]?.keyframes,
+  [
+    { opacity: 0, clipPath: "inset(0 0 0 0)" },
+    { opacity: 1, clipPath: "inset(0 0 0 0)" },
+  ],
+  "Given line-synced lyrics in clip mode, When their fade starts, Then the solid highlight is already fully revealed"
+);
+
+const instantClipFixture = renderHighlightFixture("clip", HIGHLIGHT_FIXTURE_LYRICS, {
+  "--blyrics-animate-highlight-swipe": "0",
+});
+assert.deepEqual(
+  renderedWords(instantClipFixture.mount)[0]?.animations[0]?.keyframes,
+  [
+    { opacity: 1, clipPath: "inset(0 0 0 0)" },
+    { opacity: 1, clipPath: "inset(0 0 0 0)" },
+  ],
+  "Given swipe is disabled in clip mode, When a word starts, Then its solid highlight appears fully revealed"
+);
+
+const exitingClipFixture = renderHighlightFixture("clip", [
+  {
+    startTimeMs: 1000,
+    durationMs: 1000,
+    words: "First",
+    parts: [{ startTimeMs: 1000, durationMs: 1000, words: "First" }],
+  },
+  {
+    startTimeMs: 2000,
+    durationMs: 1000,
+    words: "Second",
+    parts: [{ startTimeMs: 2000, durationMs: 1000, words: "Second" }],
+  },
+]);
+tickView(exitingClipFixture.engine, 2.2, resolveTickOptions(newTickOptions()));
+assert.deepEqual(
+  renderedWords(exitingClipFixture.mount)[0]?.animations.at(-1)?.keyframes,
+  [
+    { opacity: 1, filter: "drop-shadow(0 0 0 var(--blyrics-glow-color))", clipPath: "inset(0 0 0 0)" },
+    { opacity: 0, filter: "drop-shadow(0 0 0 var(--blyrics-glow-color))", clipPath: "inset(0 0 0 0)" },
+  ],
+  "Given a clipped word leaves its active line, When its swipe is replaced by the exit fade, Then the surface stays fully revealed while fading"
+);
+
+const invalidModeFixture = renderHighlightFixture("not-a-mode", HIGHLIGHT_FIXTURE_LYRICS);
+assert.equal(
+  invalidModeFixture.engine.cachedAnimationSettings?.config.highlight.renderMode,
+  "gradient",
+  "Given an unknown render mode, When animation settings are resolved, Then rendering safely falls back to gradient"
+);
+assert.equal(
+  setThemeSettings(new Map()),
+  true,
+  "Given a manually selected render mode, When the theme stops declaring it, Then the host is told to rebuild with the default"
+);
+
+for (const fixture of [
+  gradientFixture,
+  clipFixture,
+  lineSyncedClipFixture,
+  instantClipFixture,
+  exitingClipFixture,
+  invalidModeFixture,
+]) {
+  fixture.engine.destroy();
+}
 
 // -- Dropping one view's song leaves the other's --------------------------------------------
 

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -21,8 +21,10 @@ import {
   ANIMATING_CLASS,
   CURRENT_LYRICS_CLASS,
   FOOTER_CLASS,
+  HIGHLIGHT_CLIP_CLASS,
   LINE_CLASS,
   PAUSED_CLASS,
+  RTL_CLASS,
   USER_SCROLLING_CLASS,
 } from "./constants";
 import type { LineData, PartData } from "./inject";
@@ -53,6 +55,7 @@ const SCROLL_TIMING_BUFFER_MS = SCROLL_TIMING_RATIO_BASE_TOTAL_MS - SCROLL_TIMIN
 const AUTO_QUEUE_SCROLL_RATIO = SCROLL_TIMING_RATIO_BASE_QUEUE_SCROLL_THRESHOLD_MS / SCROLL_TIMING_RATIO_BASE_TOTAL_MS;
 const SWIPE_LEAD_RATIO = registerThemeSetting("blyrics-swipe-lead-ratio", 0.1);
 const SWIPE_DURATION_RATIO = registerThemeSetting("blyrics-swipe-duration-ratio", 1.6);
+const HIGHLIGHT_RENDER_MODE = registerThemeSetting("blyrics-highlight-render-mode", "gradient", true);
 
 const ENABLE_DEBUG_RENDER = registerThemeSetting("blyrics-debug-renderer", false);
 const ENABLE_ANIMATION_TIMING_LOGS = registerThemeSetting("blyrics-debug-animation-timing", false);
@@ -181,6 +184,7 @@ export interface AnimationEngineInstance extends AnimEngineViewState {
   pendingLineScroll: PendingLineScroll | null;
   lineScrollElementTokens: WeakMap<HTMLElement, number>;
   visibleWillChangeElements: Set<HTMLElement>;
+  visibleWillChangeViewport: VisibleWillChangeViewport | null;
   cachedDurations: Map<string, number>;
   cachedCSSValues: Map<string, string>;
   cachedAnimationSettings: AnimationSettings | null;
@@ -259,6 +263,7 @@ export function createAnimationEngineInstance(
     pendingLineScroll: null,
     lineScrollElementTokens: new WeakMap(),
     visibleWillChangeElements: new Set(),
+    visibleWillChangeViewport: null,
     cachedDurations: new Map(),
     cachedCSSValues: new Map(),
     cachedAnimationSettings: null,
@@ -473,6 +478,12 @@ interface LineScrollItem {
   height: number;
   position: number;
 }
+interface VisibleWillChangeViewport {
+  lines: readonly LineScrollItem[];
+  fromScrollTop: number;
+  toScrollTop: number;
+  viewportHeight: number;
+}
 interface LineScrollAnimationRecord {
   animation: Animation;
   lineElement: HTMLElement;
@@ -517,6 +528,7 @@ interface AnimationConfig {
     exitTo: string;
   };
   highlight: {
+    renderMode: "gradient" | "clip";
     fadeInDurationMs: number;
     fadeOutDurationMs: number;
     fadeInEasing: string;
@@ -912,7 +924,16 @@ export function noteVisibilityChange(engine: AnimationEngineInstance): void {
   });
 }
 
-function activeTextGradientKeyframes(config: AnimationConfig): Keyframe[] {
+function clipPathKeyframes(part: PartData): [string, string] {
+  const hidden = part.lyricElement.classList.contains(RTL_CLASS) ? "inset(0 0 0 100%)" : "inset(0 100% 0 0)";
+  return [hidden, "inset(0 0 0 0)"];
+}
+
+function activeTextSwipeKeyframes(part: PartData, config: AnimationConfig): Keyframe[] {
+  if (config.highlight.renderMode === "clip") {
+    const [from, to] = clipPathKeyframes(part);
+    return [{ clipPath: from }, { clipPath: to }];
+  }
   return [
     {
       "--lyric-transition-amount-start": config.highlight.swipeStartFrom,
@@ -933,7 +954,14 @@ function activeTextVisibleKeyframes(): Keyframe[] {
   return [{ opacity: 1 }, { opacity: 1 }];
 }
 
-function activeTextInstantKeyframes(config: AnimationConfig): Keyframe[] {
+function activeTextInstantKeyframes(part: PartData, config: AnimationConfig): Keyframe[] {
+  if (config.highlight.renderMode === "clip") {
+    const [, revealed] = clipPathKeyframes(part);
+    return [
+      { opacity: 1, clipPath: revealed },
+      { opacity: 1, clipPath: revealed },
+    ];
+  }
   return [
     {
       opacity: 1,
@@ -956,7 +984,14 @@ function highlightTarget(part: PartData): { element: Element; options: KeyframeA
   return { element: part.lyricElement, options: { pseudoElement: "::after" } };
 }
 
-function lineSyncedTextKeyframes(config: AnimationConfig): Keyframe[] {
+function lineSyncedTextKeyframes(part: PartData, config: AnimationConfig): Keyframe[] {
+  if (config.highlight.renderMode === "clip") {
+    const [, revealed] = clipPathKeyframes(part);
+    return [
+      { opacity: 0, clipPath: revealed },
+      { opacity: 1, clipPath: revealed },
+    ];
+  }
   return [
     {
       opacity: 0,
@@ -971,7 +1006,14 @@ function lineSyncedTextKeyframes(config: AnimationConfig): Keyframe[] {
   ] as Keyframe[];
 }
 
-function fadeOutTextKeyframes(config: AnimationConfig): Keyframe[] {
+function fadeOutTextKeyframes(part: PartData, config: AnimationConfig): Keyframe[] {
+  if (config.highlight.renderMode === "clip") {
+    const [, revealed] = clipPathKeyframes(part);
+    return [
+      { opacity: 1, filter: config.highlight.glowTo, clipPath: revealed },
+      { opacity: 0, filter: config.highlight.glowTo, clipPath: revealed },
+    ];
+  }
   return [
     {
       opacity: 1,
@@ -1005,7 +1047,7 @@ function startRichSyncedHighlightAnimations(
   if (config.enabled.highlightSwipe) {
     swipeAnimation = trackLyricAnimationTiming(
       engine,
-      target.element.animate(activeTextGradientKeyframes(config), {
+      target.element.animate(activeTextSwipeKeyframes(part, config), {
         duration: swipeDurationMs,
         easing: config.highlight.swipeEasing,
         fill: "forwards",
@@ -1020,7 +1062,7 @@ function startRichSyncedHighlightAnimations(
   const opacityAnimation = trackLyricAnimationTiming(
     engine,
     target.element.animate(
-      config.enabled.highlightSwipe ? activeTextVisibleKeyframes() : activeTextInstantKeyframes(config),
+      config.enabled.highlightSwipe ? activeTextVisibleKeyframes() : activeTextInstantKeyframes(part, config),
       {
         duration: 1,
         easing: "linear",
@@ -1066,7 +1108,7 @@ function startLineSyncedHighlightAnimations(
 
   const opacityAnimation = trackLyricAnimationTiming(
     engine,
-    target.element.animate(lineSyncedTextKeyframes(config), {
+    target.element.animate(lineSyncedTextKeyframes(part, config), {
       duration: fadeInDuration,
       easing: config.enabled.highlightFade ? config.highlight.fadeInEasing : "linear",
       fill: "forwards",
@@ -1160,6 +1202,8 @@ function startWordAnimations(
   appliedTimingOffsetMs: number
 ): void {
   resetPartAnimations(part);
+
+  part.lyricElement.classList.toggle(HIGHLIGHT_CLIP_CLASS, config.highlight.renderMode === "clip");
 
   const rawElapsedMs = (currentTime - part.time) * 1000;
   // Providers do ship words that end before they start: one -0.01s word in a Musixmatch richsync
@@ -1262,7 +1306,7 @@ function startWordExitAnimation(part: PartData, config: AnimationConfig): void {
 
   const fadeDuration = config.enabled.highlightFade ? config.highlight.fadeOutDurationMs : 1;
   const target = highlightTarget(part);
-  const animation = target.element.animate(fadeOutTextKeyframes(config), {
+  const animation = target.element.animate(fadeOutTextKeyframes(part, config), {
     duration: fadeDuration,
     easing: config.enabled.highlightFade ? config.highlight.fadeOutEasing : "linear",
     fill: "none",
@@ -1544,6 +1588,8 @@ function readAnimationConfig(engine: AnimationEngineInstance, lyricsElement: HTM
     "--blyrics-lyric-scroll-timing-function",
     "cubic-bezier(0.86, 0, 0.2, 1)"
   );
+  const configuredHighlightRenderMode = HIGHLIGHT_RENDER_MODE.getStringValue().trim().toLowerCase();
+  const highlightRenderMode = configuredHighlightRenderMode === "clip" ? "clip" : "gradient";
 
   return {
     enabled: {
@@ -1580,6 +1626,7 @@ function readAnimationConfig(engine: AnimationEngineInstance, lyricsElement: HTM
       exitTo: getCSSValue(engine, lyricsElement, "--blyrics-line-exit-transform-to", "scale(var(--blyrics-scale))"),
     },
     highlight: {
+      renderMode: highlightRenderMode,
       fadeInDurationMs: getCSSDurationWithFallback(
         engine,
         lyricsElement,
@@ -1908,6 +1955,7 @@ function clearVisibleLyricWillChange(engine: AnimationEngineInstance): void {
     element.style.removeProperty("will-change");
   }
   engine.visibleWillChangeElements = new Set();
+  engine.visibleWillChangeViewport = null;
 }
 
 function updateVisibleLyricWillChange(
@@ -1917,11 +1965,28 @@ function updateVisibleLyricWillChange(
   toScrollTop: number,
   viewportHeight: number
 ): void {
+  const previousViewport = engine.visibleWillChangeViewport;
+  if (
+    previousViewport?.lines === lines &&
+    previousViewport.fromScrollTop === fromScrollTop &&
+    previousViewport.toScrollTop === toScrollTop &&
+    previousViewport.viewportHeight === viewportHeight
+  ) {
+    return;
+  }
+
   const nextVisibleElements = new Set<HTMLElement>();
 
   for (const line of lines) {
     if (isLineVisibleDuringScroll(line, fromScrollTop, toScrollTop, viewportHeight)) {
-      line.lyricElement.style.setProperty("will-change", LINE_SCROLL_WILL_CHANGE_VALUE);
+      // Ticks run every 20ms while the song is playing, but the visible set usually changes only
+      // when the scroll position does. Rewriting the same inline declaration on every tick still
+      // enters the browser's style invalidation path and was the only DOM write in an otherwise
+      // unchanged frame. Promote a line only when it enters the set; lines already in it keep the
+      // declaration they have.
+      if (!engine.visibleWillChangeElements.has(line.lyricElement)) {
+        line.lyricElement.style.setProperty("will-change", LINE_SCROLL_WILL_CHANGE_VALUE);
+      }
       nextVisibleElements.add(line.lyricElement);
     }
   }
@@ -1933,6 +1998,7 @@ function updateVisibleLyricWillChange(
   }
 
   engine.visibleWillChangeElements = nextVisibleElements;
+  engine.visibleWillChangeViewport = { lines, fromScrollTop, toScrollTop, viewportHeight };
 }
 
 function getLineScrollItems(lines: LineData[], lyricsElement: HTMLElement): LineScrollItem[] {
@@ -2940,6 +3006,9 @@ export function relayout(engine: AnimationEngineInstance, measureLines: boolean)
   // resize report looking like a new height, and each one measures again and forces a rescroll.
   engine.lyricWidth = lyricsElement.clientWidth;
   engine.lyricHeight = lyricsElement.clientHeight;
+  // The array identity and scroll offsets may stay unchanged while wrapping moves a line into or
+  // out of the viewport. Make the next tick re-evaluate visibility against the new measurements.
+  engine.visibleWillChangeViewport = null;
 
   for (const line of engine.lines) {
     const bounds = getRelativeLayoutBounds(lyricsElement, line.lyricElement);

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -977,7 +977,7 @@ function activeTextInstantKeyframes(part: PartData, config: AnimationConfig): Ke
 }
 
 function highlightTarget(part: PartData): { element: Element; options: KeyframeAnimationOptions } {
-  const highlight = part.lyricElement.querySelector(WORD_HIGHLIGHT_SELECTOR);
+  const highlight = part.highlightElement ?? part.lyricElement.querySelector(WORD_HIGHLIGHT_SELECTOR);
   if (highlight) {
     return { element: highlight, options: {} };
   }
@@ -1204,6 +1204,7 @@ function startWordAnimations(
   resetPartAnimations(part);
 
   part.lyricElement.classList.toggle(HIGHLIGHT_CLIP_CLASS, config.highlight.renderMode === "clip");
+  part.highlightElement?.classList.toggle(HIGHLIGHT_CLIP_CLASS, config.highlight.renderMode === "clip");
 
   const rawElapsedMs = (currentTime - part.time) * 1000;
   // Providers do ship words that end before they start: one -0.01s word in a Musixmatch richsync

--- a/packages/core/src/inject.selfcheck.ts
+++ b/packages/core/src/inject.selfcheck.ts
@@ -1,5 +1,13 @@
 import { strict as assert } from "node:assert";
-import { LYRICS_CLASS, ROMANIZED_LYRICS_CLASS, TRANSLATED_LYRICS_CLASS, WORD_CLASS } from "./constants";
+import {
+  LYRICS_CLASS,
+  ROMANIZED_LYRICS_CLASS,
+  TRANSLATED_LYRICS_CLASS,
+  WORD_CLASS,
+  WORD_GROUP_CLASS,
+  WORD_HIGHLIGHT_CLASS,
+  WORD_WITH_HIGHLIGHT_CLASS,
+} from "./constants";
 import { addSeekHandler, createLyricsLine, injectRomanization, injectTranslation, newLineData } from "./inject";
 import { createInstrumentalElement } from "./instrumental";
 import { asDocument, asElement, collectTree, FakeDocument, type FactoryName, type FakeNode } from "./selfcheck/fakeDom";
@@ -84,6 +92,30 @@ assert.deepEqual(
 assert.ok(
   builtNodes.some(node => node.name === "wbr"),
   "Given a word past the wrap threshold, When it is built, Then its break nodes come from the injected document"
+);
+
+const wrappedWord = builtNodes.find(
+  node => node.classList.contains(WORD_CLASS) && node.dataset.content === "indistinguishable"
+);
+const wrappedHighlight = builtNodes.find(node => node.classList.contains(WORD_HIGHLIGHT_CLASS));
+
+assert.ok(
+  wrappedWord?.classList.contains(WORD_WITH_HIGHLIGHT_CLASS),
+  "Given a word with authored breaks, When it is built, Then its pseudo highlight is disabled"
+);
+assert.ok(
+  wrappedHighlight?.parentNode?.classList.contains(WORD_GROUP_CLASS),
+  "Given a wrapping highlight, When it is built, Then the word group owns it instead of the fragmented word"
+);
+assert.equal(
+  wrappedHighlight?.parentNode?.childNodes[0],
+  wrappedHighlight,
+  "Given a wrapping highlight, When its group is built, Then the out-of-flow copy precedes the in-flow text"
+);
+assert.equal(
+  lineData.parts[1].highlightElement,
+  wrappedHighlight,
+  "Given a wrapping highlight outside its word, When animation data is built, Then it retains the highlight target"
 );
 
 assert.deepEqual(

--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -28,6 +28,7 @@ import {
   WORD_CLASS,
   WORD_GROUP_CLASS,
   WORD_HIGHLIGHT_CLASS,
+  WORD_WITH_HIGHLIGHT_CLASS,
   ZERO_DURATION_ANIMATION_CLASS,
 } from "./constants";
 import { getSeekTimeFromClick } from "./seek";
@@ -99,6 +100,7 @@ export interface PartData {
    */
   duration: number;
   lyricElement: HTMLElement;
+  highlightElement?: HTMLElement;
   animations: Animation[];
 }
 
@@ -142,11 +144,12 @@ interface WordGroup {
   tokens: RenderToken[];
 }
 
-function newPartData(part: LyricPart, span: HTMLElement): PartData {
+function newPartData(part: LyricPart, span: HTMLElement, highlight?: HTMLElement): PartData {
   return {
     time: part.startTimeMs / 1000,
     duration: part.durationMs / 1000,
     lyricElement: span,
+    highlightElement: highlight,
     animations: [],
   };
 }
@@ -300,7 +303,11 @@ function cloneTextWithBreaks(doc: Document, source: HTMLElement): DocumentFragme
   return fragment;
 }
 
-function createTimedWordSpan(doc: Document, part: LyricPart, wrapThreshold: number): HTMLSpanElement {
+function createTimedWordSpan(
+  doc: Document,
+  part: LyricPart,
+  wrapThreshold: number
+): { span: HTMLSpanElement; highlight?: HTMLSpanElement } {
   const span = doc.createElement("span");
   span.classList.add(WORD_CLASS);
   span.dir = "auto";
@@ -323,18 +330,24 @@ function createTimedWordSpan(doc: Document, part: LyricPart, wrapThreshold: numb
   }
 
   const hasBreaks = appendLongWordBreaks(doc, span, part.words, wrapThreshold);
+  let highlight: HTMLSpanElement | undefined;
   if (hasBreaks) {
-    const highlight = doc.createElement("span");
+    highlight = doc.createElement("span");
     highlight.classList.add(WORD_HIGHLIGHT_CLASS);
     highlight.setAttribute("aria-hidden", "true");
     highlight.appendChild(cloneTextWithBreaks(doc, span));
-    span.appendChild(highlight);
+    span.classList.add(WORD_WITH_HIGHLIGHT_CLASS);
+
+    if (testRtl(part.words)) highlight.classList.add(RTL_CLASS);
+    if (part.durationMs > longWordThreshold.getNumberValue()) highlight.dataset.longWord = "true";
+    if (part.isBackground) highlight.classList.add(BACKGROUND_LYRIC_CLASS);
+    if (part.explicit) highlight.classList.add(EXPLICIT_WORD_CLASS);
   }
   span.dataset.time = String(part.startTimeMs / 1000);
   span.dataset.duration = String(part.durationMs / 1000);
   span.dataset.content = part.words;
   span.style.setProperty("--blyrics-duration", part.durationMs + "ms");
-  return span;
+  return { span, highlight };
 }
 
 function createWordGroup(doc: Document, group: WordGroup, lineData: LineData): HTMLElement {
@@ -352,13 +365,23 @@ function createWordGroup(doc: Document, group: WordGroup, lineData: LineData): H
     groupElement.classList.add(BACKGROUND_LYRIC_CLASS);
   }
 
+  const highlights: HTMLSpanElement[] = [];
+  const words: HTMLSpanElement[] = [];
+
   for (const token of group.tokens) {
     if (token.kind === "space") continue;
 
-    const span = createTimedWordSpan(doc, token.part, wrapThreshold);
-    lineData.parts.push(newPartData(token.part, span));
-    groupElement.appendChild(span);
+    const { span, highlight } = createTimedWordSpan(doc, token.part, wrapThreshold);
+    lineData.parts.push(newPartData(token.part, span, highlight));
+    if (highlight) highlights.push(highlight);
+    words.push(span);
   }
+
+  // The highlight must precede the in-flow text. If it follows a fragmented inline, browsers use
+  // the final fragment when resolving its absolute width. The content line is its containing block,
+  // so putting the out-of-flow copies first does not disturb the text or its bidi layout.
+  for (const highlight of highlights) groupElement.appendChild(highlight);
+  for (const word of words) groupElement.appendChild(word);
 
   return groupElement;
 }

--- a/packages/core/src/selfcheck/fakeDom.ts
+++ b/packages/core/src/selfcheck/fakeDom.ts
@@ -59,11 +59,13 @@ class FakeClassList {
 class FakeStyle {
   cursor = "";
   readonly properties: Record<string, string> = {};
+  readonly propertyWriteCounts: Record<string, number> = {};
   private readonly priorities: Record<string, string> = {};
 
   setProperty(name: string, value: string, priority = ""): void {
     this.properties[name] = value;
     this.priorities[name] = priority;
+    this.propertyWriteCounts[name] = (this.propertyWriteCounts[name] ?? 0) + 1;
   }
 
   getPropertyValue(name: string): string {
@@ -94,6 +96,11 @@ export class FakeAnimation {
   readonly playState = "idle";
   cancelled = false;
   playbackRate = 1;
+
+  constructor(
+    readonly keyframes: Keyframe[] | PropertyIndexedKeyframes | null = null,
+    readonly options: number | KeyframeAnimationOptions | undefined = undefined
+  ) {}
 
   cancel(): void {
     this.cancelled = true;
@@ -190,8 +197,11 @@ export class FakeNode {
     return this.generatesBox ? [this.getBoundingClientRect()] : [];
   }
 
-  animate(): FakeAnimation {
-    const animation = new FakeAnimation();
+  animate(
+    keyframes: Keyframe[] | PropertyIndexedKeyframes | null = null,
+    options?: number | KeyframeAnimationOptions
+  ): FakeAnimation {
+    const animation = new FakeAnimation(keyframes, options);
     this.animations.push(animation);
     return animation;
   }

--- a/packages/core/src/styles/lyrics.css
+++ b/packages/core/src/styles/lyrics.css
@@ -38,6 +38,7 @@
 	display: block;
 	max-width: 100%;
 	overflow-wrap: normal;
+	position: relative;
 	text-align: inherit;
 	unicode-bidi: plaintext;
 	white-space: normal;
@@ -47,6 +48,7 @@
 	display: block;
 	margin-top: 0.1em;
 	max-width: 100%;
+	position: relative;
 	text-align: inherit;
 	unicode-bidi: plaintext;
 	white-space: normal;
@@ -158,12 +160,13 @@
 	user-select: none;
 }
 
-.blyrics--word:has(.blyrics-word-highlight)::after {
+.blyrics-word-with-highlight::after {
 	content: none;
 }
 
 .blyrics-rtl.blyrics--word::after,
 .blyrics--word.blyrics-rtl::after,
+.blyrics-word-highlight.blyrics-rtl,
 .blyrics-rtl .blyrics-word-highlight,
 .blyrics--word.blyrics-rtl .blyrics-word-highlight {
 	background-image: linear-gradient(
@@ -184,7 +187,7 @@
 /* Experimental lower-cost highlight surface. The renderer adds this class only when a theme opts
  * into `blyrics-highlight-render-mode = clip;`; the gradient remains the compatibility default. */
 .blyrics--word.blyrics-highlight-clip::after,
-.blyrics--word.blyrics-highlight-clip .blyrics-word-highlight {
+.blyrics-word-highlight.blyrics-highlight-clip {
 	background-image: none;
 	background-clip: border-box;
 	clip-path: inset(0 100% 0 0);
@@ -192,7 +195,7 @@
 }
 
 .blyrics--word.blyrics-highlight-clip.blyrics-rtl::after,
-.blyrics--word.blyrics-highlight-clip.blyrics-rtl .blyrics-word-highlight {
+.blyrics-word-highlight.blyrics-highlight-clip.blyrics-rtl {
 	clip-path: inset(0 0 0 100%);
 }
 

--- a/packages/core/src/styles/lyrics.css
+++ b/packages/core/src/styles/lyrics.css
@@ -181,6 +181,21 @@
 	);
 }
 
+/* Experimental lower-cost highlight surface. The renderer adds this class only when a theme opts
+ * into `blyrics-highlight-render-mode = clip;`; the gradient remains the compatibility default. */
+.blyrics--word.blyrics-highlight-clip::after,
+.blyrics--word.blyrics-highlight-clip .blyrics-word-highlight {
+	background-image: none;
+	background-clip: border-box;
+	clip-path: inset(0 100% 0 0);
+	color: var(--blyrics-lyric-active-color);
+}
+
+.blyrics--word.blyrics-highlight-clip.blyrics-rtl::after,
+.blyrics--word.blyrics-highlight-clip.blyrics-rtl .blyrics-word-highlight {
+	clip-path: inset(0 0 0 100%);
+}
+
 [blyrics-alt-hover] .blyrics--word:hover {
 	text-decoration: underline;
 	text-underline-offset: 0.15em;

--- a/tooling/build-package.ts
+++ b/tooling/build-package.ts
@@ -7,7 +7,7 @@
 // rewritten afterwards.
 
 import { execFileSync } from "child_process";
-import { cpSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { cpSync, mkdirSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { checkApiDocs } from "./check-api-docs.js";
@@ -15,8 +15,15 @@ import { checkApiDocs } from "./check-api-docs.js";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, "..");
 const packageDir = join(root, "packages", "core");
-const outDir = join(packageDir, "dist");
 const rendererDir = join(packageDir, "src");
+const isWatchBuild = process.env.BRACCATO_PACKAGE_WATCH === "1";
+const publishedOutDir = join(packageDir, "dist");
+const outDir = isWatchBuild ? mkdtempSync(join(packageDir, ".dist-watch-")) : publishedOutDir;
+
+const removeStagingDir = () => {
+  if (isWatchBuild) rmSync(outDir, { recursive: true, force: true });
+};
+if (isWatchBuild) process.once("exit", removeStagingDir);
 
 // The manifest is `packages/core/package.json`, hand written and published from where it sits like
 // every other package here. What this script owes it is the other half of the promise: every subpath
@@ -34,7 +41,10 @@ const EMITTED_PREFIX = "./dist/";
 
 // -- Emit --------------------------------------------
 
-rmSync(outDir, { recursive: true, force: true });
+// A watch build is compiled, rewritten, copied, and checked in staging. Only the complete artifact
+// reaches dist, so linked consumers never observe tsc's extensionless imports or a missing package.
+// A one-off/package release build still cleans the published directory directly.
+if (!isWatchBuild) rmSync(outDir, { recursive: true, force: true });
 
 execFileSync("npx", ["tsc", "-p", join(__dirname, "tsconfig.package.json"), "--outDir", outDir], {
   stdio: "inherit",
@@ -114,6 +124,13 @@ cpSync(join(packageDir, "LICENSE"), join(outDir, "LICENSE"));
 // out whether they still describe it. The version travels with them, because it is the manifest's
 // now rather than something this emit writes.
 checkApiDocs(outDir, manifest.version);
+
+if (isWatchBuild) {
+  mkdirSync(publishedOutDir, { recursive: true });
+  cpSync(outDir, publishedOutDir, { recursive: true, force: true });
+  removeStagingDir();
+  process.removeListener("exit", removeStagingDir);
+}
 
 console.log(
   `Emitted @braccato/core ${manifest.version} to packages/core/dist: ${emitted.length} files, ${stylesheets.length} stylesheets`

--- a/tooling/watch-package.ts
+++ b/tooling/watch-package.ts
@@ -1,0 +1,88 @@
+// Rebuilds the published @braccato/core artifact whenever one of its inputs changes. Better Lyrics
+// links to that artifact, rather than to the TypeScript sources, so a complete package build is the
+// boundary its own dev server needs to observe.
+
+import { spawn, type ChildProcess } from "node:child_process";
+import { watch, type FSWatcher } from "node:fs";
+import { dirname, join, normalize, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const toolingDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(toolingDir, "..");
+const packageDir = join(repoRoot, "packages", "core");
+
+const PACKAGE_INPUTS = new Set(["LICENSE", "README.md", "package.json"]);
+const TOOLING_INPUTS = new Set(["build-package.ts", "check-api-docs.ts", "tsconfig.package.json"]);
+const SOURCE_PREFIX = `src${sep}`;
+const pnpm = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+let child: ChildProcess | null = null;
+let buildAgain = false;
+let debounce: NodeJS.Timeout | null = null;
+let stopping = false;
+
+const scheduleBuild = (changedPath: string) => {
+  if (stopping) return;
+
+  console.log(`[package:watch] ${changedPath} changed`);
+  if (debounce !== null) clearTimeout(debounce);
+  debounce = setTimeout(() => {
+    debounce = null;
+    runBuild();
+  }, 75);
+};
+
+const runBuild = () => {
+  if (child !== null) {
+    buildAgain = true;
+    return;
+  }
+
+  console.log("[package:watch] Building @braccato/core...");
+  child = spawn(pnpm, ["package"], {
+    cwd: repoRoot,
+    env: { ...process.env, BRACCATO_PACKAGE_WATCH: "1" },
+    stdio: "inherit",
+  });
+  child.once("error", error => {
+    console.error(`[package:watch] Could not start the package build: ${error.message}`);
+  });
+  child.once("close", code => {
+    child = null;
+    if (stopping) return;
+
+    if (code === 0) console.log("[package:watch] Watching for renderer changes...");
+    else console.error(`[package:watch] Package build failed with exit code ${code ?? "unknown"}`);
+
+    if (buildAgain) {
+      buildAgain = false;
+      runBuild();
+    }
+  });
+};
+
+const watchers: FSWatcher[] = [
+  watch(packageDir, { recursive: true }, (_event, filename) => {
+    if (filename === null) return;
+    const relative = normalize(filename);
+    if (relative.startsWith(SOURCE_PREFIX) || PACKAGE_INPUTS.has(relative)) scheduleBuild(relative);
+  }),
+  watch(toolingDir, (_event, filename) => {
+    if (filename === null) return;
+    const relative = normalize(filename);
+    if (TOOLING_INPUTS.has(relative)) scheduleBuild(join("tooling", relative));
+  }),
+];
+
+const stop = () => {
+  if (stopping) return;
+  stopping = true;
+  if (debounce !== null) clearTimeout(debounce);
+  for (const watcher of watchers) watcher.close();
+  if (child !== null) child.kill("SIGTERM");
+};
+
+process.once("SIGINT", stop);
+process.once("SIGTERM", stop);
+
+runBuild();


### PR DESCRIPTION
## Summary

- Add package watch tooling for faster development builds.
- Update core rendering and highlighting behavior for fragmented words.
- Refresh demo playback, themes, styling, and documentation.
- Ignore local IntelliJ project files.

## Testing

- Not run.