### PR TITLE
refactor(core): require highlight targets in part data

### DIFF
--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -25,7 +25,7 @@ import {
   PAUSED_CLASS,
   USER_SCROLLING_CLASS,
 } from "./constants";
-import type { LineData, PartData } from "./inject";
+import type { AnimationData, LineData, PartData } from "./inject";
 import { INSTRUMENTAL_WAVE_PATH_HIGH, INSTRUMENTAL_WAVE_PATH_LOW } from "./instrumental";
 import { registerThemeSetting } from "./themeSettings";
 import type { LyricsRendererHost, LyricSyncType, ResolvedTickOptions, TickOptions } from "./types";
@@ -412,7 +412,7 @@ export function clearLyrics(engine: AnimationEngineInstance): void {
   engine.lyricsContainer = null;
 }
 
-function resetPartAnimations(part: PartData): void {
+function resetPartAnimations(part: AnimationData): void {
   for (const animation of part.animations) {
     animation.cancel();
   }
@@ -439,9 +439,11 @@ function resetLineAnimationState(lineData: LineData): void {
   markLineAnimationsStopped(lineData);
 }
 
-function togglePartClass(part: PartData, className: string, force: boolean): void {
+function togglePartClass(part: LineData | PartData, className: string, force: boolean): void {
   part.lyricElement.classList.toggle(className, force);
-  part.highlightElement?.classList.toggle(className, force);
+  if ("highlightElement" in part) {
+    part.highlightElement.classList.toggle(className, force);
+  }
 }
 
 function setAnimationsPlayState(lineData: LineData, isPlaying: boolean): void {
@@ -709,7 +711,7 @@ function normalizeAnimationTimeMs(animation: Animation, timeMs: number, timing: 
 }
 
 function animationTimingSample(
-  part: PartData,
+  part: AnimationData,
   animation: Animation,
   currentTime: number
 ): NativeAnimationTimingSample | null {
@@ -750,7 +752,7 @@ function animationTimingSample(
   };
 }
 
-function largestNativeTimingSample(part: PartData, currentTime: number): NativeAnimationTimingSample | null {
+function largestNativeTimingSample(part: AnimationData, currentTime: number): NativeAnimationTimingSample | null {
   let largestSample: NativeAnimationTimingSample | null = null;
 
   for (const animation of part.animations) {
@@ -998,7 +1000,7 @@ function startRichSyncedHighlightAnimations(
   appliedTimingOffsetMs: number
 ): HighlightAnimations {
   const animations: Animation[] = [];
-  const highlight = part.highlightElement!;
+  const highlight = part.highlightElement;
 
   let swipeAnimation: Animation | undefined;
   if (config.enabled.highlightSwipe) {
@@ -1058,7 +1060,7 @@ function startLineSyncedHighlightAnimations(
 ): HighlightAnimations {
   const animations: Animation[] = [];
   const fadeInDuration = config.enabled.highlightFade ? config.highlight.fadeInDurationMs : 1;
-  const highlight = part.highlightElement!;
+  const highlight = part.highlightElement;
 
   const opacityAnimation = trackLyricAnimationTiming(
     engine,
@@ -1216,7 +1218,7 @@ function startWordAnimations(
     const wobbleStartMs = correctedAnimationTimeMs(wordTimeMs, appliedTimingOffsetMs, config.word.wobbleDurationMs);
     // The wobble is a paint transform, so the highlight copy must carry it too or the active
     // sweep drifts off the word.
-    for (const wordElement of [part.lyricElement, part.highlightElement!]) {
+    for (const wordElement of [part.lyricElement, part.highlightElement]) {
       const animation = trackLyricAnimationTiming(engine, wordElement.animate(wobbleKeyframes, wobbleOptions), {
         appliedTimingOffsetMs,
         offsetMs: 0,
@@ -1251,7 +1253,7 @@ function startWordExitAnimation(part: PartData, config: AnimationConfig): void {
   resetPartAnimations(part);
 
   const fadeDuration = config.enabled.highlightFade ? config.highlight.fadeOutDurationMs : 1;
-  const animation = part.highlightElement!.animate(fadeOutTextKeyframes(config), {
+  const animation = part.highlightElement.animate(fadeOutTextKeyframes(config), {
     duration: fadeDuration,
     easing: config.enabled.highlightFade ? config.highlight.fadeOutEasing : "linear",
     fill: "none",

--- a/packages/core/src/inject.selfcheck.ts
+++ b/packages/core/src/inject.selfcheck.ts
@@ -129,7 +129,7 @@ assert.equal(
   "Given a wrapping word, When both runs are built, Then the visible and highlighted text are identical"
 );
 assert.deepEqual(
-  lineData.parts.map(part => part.highlightElement?.dataset.content),
+  lineData.parts.map(part => part.highlightElement.dataset.content),
   lineData.parts.map(part => part.lyricElement.dataset.content),
   "Given a timed line, When both runs are built, Then every highlight maps to the same word content"
 );

--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -89,7 +89,7 @@ export function deriveSyncType(lyrics: Lyric[]): LyricSyncType {
   return lyrics.every(item => item.startTimeMs === 0) ? "none" : "synced";
 }
 
-export interface PartData {
+export interface AnimationData {
   /**
    * Time of this part in seconds
    */
@@ -101,9 +101,10 @@ export interface PartData {
   duration: number;
   lyricElement: HTMLElement;
   animations: Animation[];
-  // Renderer-created word records always have this target. It remains optional so adding it does
-  // not break consumers that construct the public PartData shape themselves.
-  highlightElement?: HTMLElement;
+}
+
+export interface PartData extends AnimationData {
+  highlightElement: HTMLElement;
 }
 
 export type LineData = {
@@ -116,7 +117,7 @@ export type LineData = {
   isSelected: boolean;
   height: number;
   position: number;
-} & PartData;
+} & AnimationData;
 
 type SpaceToken = {
   kind: "space";


### PR DESCRIPTION
## Motivation

After #9, every renderer-created word has a real highlight element and every word animation depends on it. Keeping `PartData.highlightElement` optional no longer described a valid word record: it allowed incomplete construction and forced the animation engine to use non-null assertions for an invariant the builder already guarantees.

The field was optional because `LineData` previously reused the complete `PartData` shape even though a line is not a word and has no highlight target. That modeling shortcut weakened the word type instead of describing the distinction between lines and words.

## Approach

- Extract the timing, lyric-element, and animation fields shared by lines and words into `AnimationData`.
- Make `PartData.highlightElement` required.
- Build `LineData` from the shared animation fields without pretending that a line has a word-highlight target.
- Type engine helpers that operate on either lines or words against the shared shape, while word-only animation paths use the required highlight directly.
- Remove the remaining non-null assertions and make the builder self-check access highlight targets without optional chaining.

This is a type-modeling cleanup; it does not change the rendered DOM or animation behavior.

## Validation

- `pnpm lint`
- `pnpm --filter @braccato/core typecheck`
- `pnpm --filter @braccato/core selfcheck`
- `pnpm test`
- `pnpm build`
