### PR TITLE
Decode HTML entities in TTML lyrics via fast-xml-parser

### DIFF
--- a/packages/parsers/src/__tests__/ttml.test.ts
+++ b/packages/parsers/src/__tests__/ttml.test.ts
@@ -92,6 +92,25 @@ describe("TTMLParser", () => {
 			expect(nonInstrumental[0].parts!.length).toBeGreaterThanOrEqual(2);
 		});
 
+		it("decodes HTML and XML entities in line and word text", () => {
+			const ttml = `<?xml version="1.0" encoding="UTF-8"?>
+<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="en">
+  <head><metadata></metadata></head>
+  <body dur="30s">
+    <div>
+      <p begin="5s" end="10s" key="l1">It&rsquo;s caf&#233; &amp; more&#8230;</p>
+      <p begin="10s" end="15s" key="l2"><span begin="10s" end="12s">don&#39;t</span><span begin="12s" end="15s">na&#xEF;ve</span></p>
+    </div>
+  </body>
+</tt>`;
+
+			const result = TTMLParser.parse(ttml);
+			const nonInstrumental = result.filter((l) => !l.isInstrumental);
+
+			expect(nonInstrumental[0].words).toBe("It’s café & more…");
+			expect(nonInstrumental[1].parts!.map((p) => p.words)).toEqual(["don't", "naïve"]);
+		});
+
 		it("detects language", () => {
 			const ttml = `<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="ja">
   <head><metadata></metadata></head>

--- a/packages/parsers/src/ttml.ts
+++ b/packages/parsers/src/ttml.ts
@@ -204,6 +204,7 @@ const PARSER_OPTIONS: X2jOptions = {
 	allowBooleanAttributes: true,
 	parseAttributeValue: false,
 	parseTagValue: false,
+	htmlEntities: true,
 };
 
 export interface ParseTTMLOptions {


### PR DESCRIPTION
## Overview

Same goal as #12, decode HTML entities in TTML lyrics, but through the parser we already ship instead of a hand-rolled decoder.

Setting `htmlEntities: true` in the parser options covers `&rsquo;`, `&mdash;`, `&ndash;`, `&hellip;`, `&copy;`, `&nbsp;` and the rest, a strict superset of the 16 entities #12 hardcoded. `processEntities` (on by default) already handles the XML entities (`&amp;`, `&apos;`, `&quot;`, `&lt;`, `&gt;`) and numeric refs (`&#39;`, `&#xEF;`), so nothing else is needed.

This also avoids the double-decode in #12: there the custom pass ran once inside the value processors and again in `collectSpanText`/`parseLyricPart` over the same text, which over-decodes legitimately-escaped literals like `&amp;#39;`. One option, one owner, nothing new to maintain.

Added a parser test covering named, decimal and hex entities across both line-synced and word-synced text.