### PR TITLE
feat(core): animate streamed translation and romanization entry

### DIFF
--- a/demo/api.js
+++ b/demo/api.js
@@ -9,14 +9,17 @@
 // stops where the reasoning starts. The reasoning lives beside the code it explains, in the module's
 // own file headers.
 
+import corePackage from "@braccato/core/package.json" with { type: "json" };
+
 // -- The package --------------------------------------------
 
-// `version` is checked against the emitted package.json, so the number on the page cannot drift from
-// the number in the artifact. There is no separate README link, because both of these already land
-// on it: npm renders the README as the package page, and GitHub renders it under the directory.
+// `version` comes straight from the package's own manifest, so the number on the page is the
+// artifact's by construction and cannot drift. There is no separate README link, because both of
+// these already land on it: npm renders the README as the package page, and GitHub renders it under
+// the directory.
 export const PACKAGE = {
   name: "@braccato/core",
-  version: "1.3.0",
+  version: corePackage.version,
   npmHref: "https://www.npmjs.com/package/@braccato/core",
   repoHref: "https://github.com/better-lyrics/braccato/tree/master/packages/core",
 };

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -44,6 +44,9 @@
 
 	/* The module's own tokens, sized for a full page rather than for a music player's side panel. */
 	--blyrics-font-size: clamp(1.75rem, 4.4vw, 3.25rem);
+	/* Tracked off the main size rather than the module's fixed 2rem default, so a translation or
+	   romanization stays smaller than the line it sits under at every viewport width. */
+	--blyrics-translated-font-size: calc(var(--blyrics-font-size) * 0.62);
 	--blyrics-line-height: 1.2;
 	--blyrics-padding: 0.8rem;
 
@@ -1623,6 +1626,21 @@ braccato-lyrics {
    cannot reach the view's target scroll position. */
 .blyrics-container {
 	padding-top: var(--blyrics-padding-top, 2rem);
+}
+
+/* The package floats a streamed-in translation or romanization in; the demo's Hide control plays the
+   reverse (compositor-only, so no clipping or stutter) and then slides the lines up to close the gap
+   with a FLIP. The same toggle drops the fade to an instant removal. */
+.blyrics--leaving {
+	animation: blyrics-decoration-out calc(var(--blyrics-animate-decoration-entry) * 0.25s)
+		cubic-bezier(0.25, 1, 0.5, 1) both;
+}
+
+@keyframes blyrics-decoration-out {
+	to {
+		opacity: 0;
+		transform: translateY(-0.4em);
+	}
 }
 
 /* The page's default tracking, tightened a little because the lyric type is large enough to want it.

--- a/demo/demo.css
+++ b/demo/demo.css
@@ -44,9 +44,7 @@
 
 	/* The module's own tokens, sized for a full page rather than for a music player's side panel. */
 	--blyrics-font-size: clamp(1.75rem, 4.4vw, 3.25rem);
-	/* Tracked off the main size rather than the module's fixed 2rem default, so a translation or
-	   romanization stays smaller than the line it sits under at every viewport width. */
-	--blyrics-translated-font-size: calc(var(--blyrics-font-size) * 0.62);
+	--blyrics-translated-font-size: calc(var(--blyrics-font-size) * 0.48);
 	--blyrics-line-height: 1.2;
 	--blyrics-padding: 0.8rem;
 
@@ -1628,9 +1626,6 @@ braccato-lyrics {
 	padding-top: var(--blyrics-padding-top, 2rem);
 }
 
-/* The package floats a streamed-in translation or romanization in; the demo's Hide control plays the
-   reverse (compositor-only, so no clipping or stutter) and then slides the lines up to close the gap
-   with a FLIP. The same toggle drops the fade to an instant removal. */
 .blyrics--leaving {
 	animation: blyrics-decoration-out calc(var(--blyrics-animate-decoration-entry) * 0.25s)
 		cubic-bezier(0.25, 1, 0.5, 1) both;

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -103,9 +103,6 @@ const animateDecorationsInput = document.getElementById("animate-decorations");
 const eventLog = document.getElementById("event-log");
 const dropzone = document.getElementById("dropzone");
 
-// Illustrative pairs the "Show translations & romanizations" control hangs off the lines, cycled by
-// line. A provider streams these in after the words; the demo has none of its own, so the animation
-// is what is on show, not the text.
 const DEMO_DECORATIONS = [
   { roman: "hikari no naka de", trans: "inside the light" },
   { roman: "kaze ga fuku hi ni", trans: "on a day the wind blows" },
@@ -572,7 +569,6 @@ function applyLyrics() {
   view.lyrics = lyrics;
   applied.lyrics = lyrics;
 
-  // A fresh build replaces every line, so any decorations hung off the old ones are gone.
   setDecorationsShown(false);
 
   const json = JSON.stringify(lyrics, null, 2);
@@ -1314,10 +1310,6 @@ function liveDecorations() {
   return [...document.querySelectorAll(DECORATION_SELECTOR)].filter(el => !el.classList.contains("blyrics--leaving"));
 }
 
-// FLIP the lines: measure, run the mutation that changes their heights, then animate each one from
-// where it was to where it lands. It writes the `translate` longhand, which the scroll engine leaves
-// alone between scrolls and which composes with the `transform: scale` it owns, so the slide never
-// fights the sweep. The decorators themselves float in and out on their own through the package CSS.
 function slideLines(mutate) {
   const lineEls = (view.renderer?.lines ?? []).map(line => line.lyricElement).filter(Boolean);
   if (!animateDecorationsInput.checked || lineEls.length === 0) {
@@ -1339,9 +1331,6 @@ function slideLines(mutate) {
   });
 }
 
-// Hangs a romanization and a translation off every sung line, the way a provider streams them in
-// after the words, so the entry animation in the package CSS has something to play. Clicking again
-// plays the reverse and pulls them back off.
 function toggleDecorations() {
   if (liveDecorations().length > 0) hideDecorations();
   else showDecorations();
@@ -1372,8 +1361,6 @@ function hideDecorations() {
     return;
   }
 
-  // The decorators float out first, the lines holding still, then the lines slide up to close the gap
-  // as the nodes are pulled: the reverse of the entry, and never on the layout path.
   leaving.forEach(el => el.classList.add("blyrics--leaving"));
   setTimeout(() => slideLines(() => leaving.forEach(el => el.remove())), DECORATION_FADE_MS);
 }

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -97,9 +97,26 @@ const offsetValue = document.getElementById("offset-value");
 const passiveScrollInput = document.getElementById("passive-scroll");
 const viewScrollInput = document.getElementById("scrollable-view");
 const pageRulesInput = document.getElementById("page-rules");
+const injectDecorationsButton = document.getElementById("inject-decorations");
+const animateDecorationsInput = document.getElementById("animate-decorations");
 
 const eventLog = document.getElementById("event-log");
 const dropzone = document.getElementById("dropzone");
+
+// Illustrative pairs the "Show translations & romanizations" control hangs off the lines, cycled by
+// line. A provider streams these in after the words; the demo has none of its own, so the animation
+// is what is on show, not the text.
+const DEMO_DECORATIONS = [
+  { roman: "hikari no naka de", trans: "inside the light" },
+  { roman: "kaze ga fuku hi ni", trans: "on a day the wind blows" },
+  { roman: "kimi no koe ga suru", trans: "I can hear your voice" },
+  { roman: "yoru wo koete", trans: "past the night" },
+  { roman: "tooku made", trans: "as far as it goes" },
+  { roman: "mou ichido", trans: "one more time" },
+];
+
+let injectTranslation = () => false;
+let injectRomanization = () => false;
 
 // -- Before the module exists --------------------------------------------
 
@@ -554,6 +571,9 @@ function applyLyrics() {
   view.lyricsOptions = { noLyrics: state.importedLyrics === null && state.timing === "empty" };
   view.lyrics = lyrics;
   applied.lyrics = lyrics;
+
+  // A fresh build replaces every line, so any decorations hung off the old ones are gone.
+  setDecorationsShown(false);
 
   const json = JSON.stringify(lyrics, null, 2);
   lyricsArray.textContent =
@@ -1271,17 +1291,105 @@ function wireControls(lineClass, lyricsClass) {
     // this page just moved under it.
     view.renderer?.relayout();
   });
+
+  injectDecorationsButton.addEventListener("click", toggleDecorations);
+
+  animateDecorationsInput.addEventListener("change", () => {
+    view.style.setProperty("--blyrics-animate-decoration-entry", animateDecorationsInput.checked ? "1" : "0");
+  });
+}
+
+const DECORATION_SELECTOR = ".blyrics--translated, .blyrics--romanized";
+const DECORATION_SLIDE_MS = 350;
+const DECORATION_FADE_MS = 250;
+const DECORATION_EASE = "cubic-bezier(0.25, 1, 0.5, 1)";
+
+function setDecorationsShown(shown) {
+  injectDecorationsButton.textContent = shown
+    ? "Hide translations & romanizations"
+    : "Show translations & romanizations";
+}
+
+function liveDecorations() {
+  return [...document.querySelectorAll(DECORATION_SELECTOR)].filter(el => !el.classList.contains("blyrics--leaving"));
+}
+
+// FLIP the lines: measure, run the mutation that changes their heights, then animate each one from
+// where it was to where it lands. It writes the `translate` longhand, which the scroll engine leaves
+// alone between scrolls and which composes with the `transform: scale` it owns, so the slide never
+// fights the sweep. The decorators themselves float in and out on their own through the package CSS.
+function slideLines(mutate) {
+  const lineEls = (view.renderer?.lines ?? []).map(line => line.lyricElement).filter(Boolean);
+  if (!animateDecorationsInput.checked || lineEls.length === 0) {
+    mutate();
+    view.renderer?.relayout();
+    return;
+  }
+
+  const first = lineEls.map(el => el.getBoundingClientRect().top);
+  mutate();
+  view.renderer?.relayout();
+  lineEls.forEach((el, i) => {
+    const dy = first[i] - el.getBoundingClientRect().top;
+    if (Math.abs(dy) < 0.5) return;
+    el.animate(
+      { translate: [`0 ${dy}px`, "0 0"] },
+      { duration: DECORATION_SLIDE_MS, easing: DECORATION_EASE, composite: "add" }
+    );
+  });
+}
+
+// Hangs a romanization and a translation off every sung line, the way a provider streams them in
+// after the words, so the entry animation in the package CSS has something to play. Clicking again
+// plays the reverse and pulls them back off.
+function toggleDecorations() {
+  if (liveDecorations().length > 0) hideDecorations();
+  else showDecorations();
+}
+
+function showDecorations() {
+  slideLines(() => {
+    (view.renderer?.lines ?? []).forEach((line, index) => {
+      const el = line.lyricElement;
+      if (!el || el.dataset.instrumental) return;
+      const pair = DEMO_DECORATIONS[index % DEMO_DECORATIONS.length];
+      injectRomanization(document, el, line, pair.roman);
+      injectTranslation(document, el, pair.trans);
+    });
+  });
+  if (liveDecorations().length === 0) return;
+  setDecorationsShown(true);
+}
+
+function hideDecorations() {
+  const leaving = liveDecorations();
+  if (leaving.length === 0) return;
+  setDecorationsShown(false);
+
+  if (!animateDecorationsInput.checked) {
+    leaving.forEach(el => el.remove());
+    view.renderer?.relayout();
+    return;
+  }
+
+  // The decorators float out first, the lines holding still, then the lines slide up to close the gap
+  // as the nodes are pulled: the reverse of the entry, and never on the layout path.
+  leaving.forEach(el => el.classList.add("blyrics--leaving"));
+  setTimeout(() => slideLines(() => leaving.forEach(el => el.remove())), DECORATION_FADE_MS);
 }
 
 // -- Boot --------------------------------------------
 
 async function boot() {
-  const [, { CUSTOM_THEME_STYLE_ID, LINE_CLASS, LYRICS_CLASS }, themeSettings] = await Promise.all([
+  const [, { CUSTOM_THEME_STYLE_ID, LINE_CLASS, LYRICS_CLASS }, themeSettings, core] = await Promise.all([
     import("@braccato/core/element"),
     import("@braccato/core/constants"),
     import("@braccato/core/themeSettings"),
+    import("@braccato/core"),
   ]);
   parseThemeConfig = themeSettings.parseThemeConfig;
+  injectTranslation = core.injectTranslation;
+  injectRomanization = core.injectRomanization;
 
   for (const type of ["braccato:lyrics-loaded", "braccato:line-click", "braccato:scroll-state", "braccato:error"]) {
     view.addEventListener(type, logEvent);

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -99,6 +99,7 @@ const viewScrollInput = document.getElementById("scrollable-view");
 const pageRulesInput = document.getElementById("page-rules");
 const injectRomanizationsButton = document.getElementById("inject-romanizations");
 const injectTranslationsButton = document.getElementById("inject-translations");
+const injectBothButton = document.getElementById("inject-both");
 const animateDecorationsInput = document.getElementById("animate-decorations");
 
 const eventLog = document.getElementById("event-log");
@@ -570,8 +571,7 @@ function applyLyrics() {
   view.lyrics = lyrics;
   applied.lyrics = lyrics;
 
-  setDecorationsShown("romanization", false);
-  setDecorationsShown("translation", false);
+  paintDecorationButtons();
 
   const json = JSON.stringify(lyrics, null, 2);
   lyricsArray.textContent =
@@ -1290,94 +1290,84 @@ function wireControls(lineClass, lyricsClass) {
     view.renderer?.relayout();
   });
 
-  injectRomanizationsButton.addEventListener("click", () => toggleDecorations("romanization"));
-  injectTranslationsButton.addEventListener("click", () => toggleDecorations("translation"));
+  injectRomanizationsButton.addEventListener("click", () => toggleKinds(["romanization"]));
+  injectTranslationsButton.addEventListener("click", () => toggleKinds(["translation"]));
+  injectBothButton.addEventListener("click", toggleBothDecorations);
 
   animateDecorationsInput.addEventListener("change", () => {
     view.style.setProperty("--blyrics-animate-decoration-entry", animateDecorationsInput.checked ? "1" : "0");
   });
 }
 
-const DECORATION_SLIDE_MS = 350;
 const DECORATION_FADE_MS = 250;
-const DECORATION_EASE = "cubic-bezier(0.25, 1, 0.5, 1)";
 
 const DECORATION_KINDS = {
   romanization: {
-    noun: "romanizations",
     selector: ".blyrics--romanized",
-    button: injectRomanizationsButton,
     inject: (line, pair) => injectRomanization(document, line.lyricElement, line, pair.roman),
   },
   translation: {
-    noun: "translations",
     selector: ".blyrics--translated",
-    button: injectTranslationsButton,
     inject: (line, pair) => injectTranslation(document, line.lyricElement, pair.trans),
   },
 };
-
-function setDecorationsShown(kind, shown) {
-  const { button, noun } = DECORATION_KINDS[kind];
-  button.textContent = `${shown ? "Hide" : "Show"} ${noun}`;
-}
 
 function liveDecorations(selector) {
   return [...document.querySelectorAll(selector)].filter(el => !el.classList.contains("blyrics--leaving"));
 }
 
-function slideLines(mutate) {
-  const lineEls = (view.renderer?.lines ?? []).map(line => line.lyricElement).filter(Boolean);
-  if (!animateDecorationsInput.checked || lineEls.length === 0) {
-    mutate();
-    view.renderer?.relayout();
-    return;
-  }
-
-  const first = lineEls.map(el => el.getBoundingClientRect().top);
-  mutate();
-  view.renderer?.relayout();
-  lineEls.forEach((el, i) => {
-    const dy = first[i] - el.getBoundingClientRect().top;
-    if (Math.abs(dy) < 0.5) return;
-    el.animate(
-      { translate: [`0 ${dy}px`, "0 0"] },
-      { duration: DECORATION_SLIDE_MS, easing: DECORATION_EASE, composite: "add" }
-    );
-  });
+function decorationSelector(kinds) {
+  return kinds.map(kind => DECORATION_KINDS[kind].selector).join(", ");
 }
 
-function toggleDecorations(kind) {
-  if (liveDecorations(DECORATION_KINDS[kind].selector).length > 0) hideDecorations(kind);
-  else showDecorations(kind);
+function paintDecorationButtons() {
+  const roman = liveDecorations(DECORATION_KINDS.romanization.selector).length > 0;
+  const trans = liveDecorations(DECORATION_KINDS.translation.selector).length > 0;
+  injectRomanizationsButton.textContent = roman ? "Hide romanizations" : "Show romanizations";
+  injectTranslationsButton.textContent = trans ? "Hide translations" : "Show translations";
+  injectBothButton.textContent = roman && trans ? "Hide both" : "Show both";
 }
 
-function showDecorations(kind) {
-  const k = DECORATION_KINDS[kind];
-  slideLines(() => {
+function showDecorations(kinds) {
+  view.renderer?.animateDecorationChange(() => {
     (view.renderer?.lines ?? []).forEach((line, index) => {
       const el = line.lyricElement;
       if (!el || el.dataset.instrumental) return;
-      k.inject(line, DEMO_DECORATIONS[index % DEMO_DECORATIONS.length]);
+      const pair = DEMO_DECORATIONS[index % DEMO_DECORATIONS.length];
+      kinds.forEach(kind => DECORATION_KINDS[kind].inject(line, pair));
     });
   });
-  if (liveDecorations(k.selector).length === 0) return;
-  setDecorationsShown(kind, true);
+  paintDecorationButtons();
 }
 
-function hideDecorations(kind) {
-  const leaving = liveDecorations(DECORATION_KINDS[kind].selector);
+function hideDecorations(kinds) {
+  const leaving = liveDecorations(decorationSelector(kinds));
   if (leaving.length === 0) return;
-  setDecorationsShown(kind, false);
 
   if (!animateDecorationsInput.checked) {
-    leaving.forEach(el => el.remove());
-    view.renderer?.relayout();
+    view.renderer?.animateDecorationChange(() => leaving.forEach(el => el.remove()));
+    paintDecorationButtons();
     return;
   }
 
   leaving.forEach(el => el.classList.add("blyrics--leaving"));
-  setTimeout(() => slideLines(() => leaving.forEach(el => el.remove())), DECORATION_FADE_MS);
+  paintDecorationButtons();
+  setTimeout(
+    () => view.renderer?.animateDecorationChange(() => leaving.forEach(el => el.remove())),
+    DECORATION_FADE_MS
+  );
+}
+
+function toggleKinds(kinds) {
+  if (liveDecorations(decorationSelector(kinds)).length > 0) hideDecorations(kinds);
+  else showDecorations(kinds);
+}
+
+function toggleBothDecorations() {
+  const roman = liveDecorations(DECORATION_KINDS.romanization.selector).length > 0;
+  const trans = liveDecorations(DECORATION_KINDS.translation.selector).length > 0;
+  if (roman && trans) hideDecorations(["romanization", "translation"]);
+  else showDecorations(["romanization", "translation"]);
 }
 
 // -- Boot --------------------------------------------

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -1328,15 +1328,21 @@ function paintDecorationButtons() {
   injectBothButton.textContent = roman && trans ? "Hide both" : "Show both";
 }
 
+function repositionDecorations() {
+  view.renderer?.scheduleLyricPositionUpdate(
+    () => true,
+    () => {}
+  );
+}
+
 function showDecorations(kinds) {
-  view.renderer?.animateDecorationChange(() => {
-    (view.renderer?.lines ?? []).forEach((line, index) => {
-      const el = line.lyricElement;
-      if (!el || el.dataset.instrumental) return;
-      const pair = DEMO_DECORATIONS[index % DEMO_DECORATIONS.length];
-      kinds.forEach(kind => DECORATION_KINDS[kind].inject(line, pair));
-    });
+  (view.renderer?.lines ?? []).forEach((line, index) => {
+    const el = line.lyricElement;
+    if (!el || el.dataset.instrumental) return;
+    const pair = DEMO_DECORATIONS[index % DEMO_DECORATIONS.length];
+    kinds.forEach(kind => DECORATION_KINDS[kind].inject(line, pair));
   });
+  repositionDecorations();
   paintDecorationButtons();
 }
 
@@ -1345,17 +1351,18 @@ function hideDecorations(kinds) {
   if (leaving.length === 0) return;
 
   if (!animateDecorationsInput.checked) {
-    view.renderer?.animateDecorationChange(() => leaving.forEach(el => el.remove()));
+    leaving.forEach(el => el.remove());
+    repositionDecorations();
     paintDecorationButtons();
     return;
   }
 
   leaving.forEach(el => el.classList.add("blyrics--leaving"));
   paintDecorationButtons();
-  setTimeout(
-    () => view.renderer?.animateDecorationChange(() => leaving.forEach(el => el.remove())),
-    DECORATION_FADE_MS
-  );
+  setTimeout(() => {
+    leaving.forEach(el => el.remove());
+    repositionDecorations();
+  }, DECORATION_FADE_MS);
 }
 
 function toggleKinds(kinds) {

--- a/demo/demo.js
+++ b/demo/demo.js
@@ -97,7 +97,8 @@ const offsetValue = document.getElementById("offset-value");
 const passiveScrollInput = document.getElementById("passive-scroll");
 const viewScrollInput = document.getElementById("scrollable-view");
 const pageRulesInput = document.getElementById("page-rules");
-const injectDecorationsButton = document.getElementById("inject-decorations");
+const injectRomanizationsButton = document.getElementById("inject-romanizations");
+const injectTranslationsButton = document.getElementById("inject-translations");
 const animateDecorationsInput = document.getElementById("animate-decorations");
 
 const eventLog = document.getElementById("event-log");
@@ -569,7 +570,8 @@ function applyLyrics() {
   view.lyrics = lyrics;
   applied.lyrics = lyrics;
 
-  setDecorationsShown(false);
+  setDecorationsShown("romanization", false);
+  setDecorationsShown("translation", false);
 
   const json = JSON.stringify(lyrics, null, 2);
   lyricsArray.textContent =
@@ -1288,26 +1290,40 @@ function wireControls(lineClass, lyricsClass) {
     view.renderer?.relayout();
   });
 
-  injectDecorationsButton.addEventListener("click", toggleDecorations);
+  injectRomanizationsButton.addEventListener("click", () => toggleDecorations("romanization"));
+  injectTranslationsButton.addEventListener("click", () => toggleDecorations("translation"));
 
   animateDecorationsInput.addEventListener("change", () => {
     view.style.setProperty("--blyrics-animate-decoration-entry", animateDecorationsInput.checked ? "1" : "0");
   });
 }
 
-const DECORATION_SELECTOR = ".blyrics--translated, .blyrics--romanized";
 const DECORATION_SLIDE_MS = 350;
 const DECORATION_FADE_MS = 250;
 const DECORATION_EASE = "cubic-bezier(0.25, 1, 0.5, 1)";
 
-function setDecorationsShown(shown) {
-  injectDecorationsButton.textContent = shown
-    ? "Hide translations & romanizations"
-    : "Show translations & romanizations";
+const DECORATION_KINDS = {
+  romanization: {
+    noun: "romanizations",
+    selector: ".blyrics--romanized",
+    button: injectRomanizationsButton,
+    inject: (line, pair) => injectRomanization(document, line.lyricElement, line, pair.roman),
+  },
+  translation: {
+    noun: "translations",
+    selector: ".blyrics--translated",
+    button: injectTranslationsButton,
+    inject: (line, pair) => injectTranslation(document, line.lyricElement, pair.trans),
+  },
+};
+
+function setDecorationsShown(kind, shown) {
+  const { button, noun } = DECORATION_KINDS[kind];
+  button.textContent = `${shown ? "Hide" : "Show"} ${noun}`;
 }
 
-function liveDecorations() {
-  return [...document.querySelectorAll(DECORATION_SELECTOR)].filter(el => !el.classList.contains("blyrics--leaving"));
+function liveDecorations(selector) {
+  return [...document.querySelectorAll(selector)].filter(el => !el.classList.contains("blyrics--leaving"));
 }
 
 function slideLines(mutate) {
@@ -1331,29 +1347,28 @@ function slideLines(mutate) {
   });
 }
 
-function toggleDecorations() {
-  if (liveDecorations().length > 0) hideDecorations();
-  else showDecorations();
+function toggleDecorations(kind) {
+  if (liveDecorations(DECORATION_KINDS[kind].selector).length > 0) hideDecorations(kind);
+  else showDecorations(kind);
 }
 
-function showDecorations() {
+function showDecorations(kind) {
+  const k = DECORATION_KINDS[kind];
   slideLines(() => {
     (view.renderer?.lines ?? []).forEach((line, index) => {
       const el = line.lyricElement;
       if (!el || el.dataset.instrumental) return;
-      const pair = DEMO_DECORATIONS[index % DEMO_DECORATIONS.length];
-      injectRomanization(document, el, line, pair.roman);
-      injectTranslation(document, el, pair.trans);
+      k.inject(line, DEMO_DECORATIONS[index % DEMO_DECORATIONS.length]);
     });
   });
-  if (liveDecorations().length === 0) return;
-  setDecorationsShown(true);
+  if (liveDecorations(k.selector).length === 0) return;
+  setDecorationsShown(kind, true);
 }
 
-function hideDecorations() {
-  const leaving = liveDecorations();
+function hideDecorations(kind) {
+  const leaving = liveDecorations(DECORATION_KINDS[kind].selector);
   if (leaving.length === 0) return;
-  setDecorationsShown(false);
+  setDecorationsShown(kind, false);
 
   if (!animateDecorationsInput.checked) {
     leaving.forEach(el => el.remove());

--- a/demo/index.html
+++ b/demo/index.html
@@ -325,11 +325,12 @@
           <p class="group__hint" id="timing-hint"></p>
 
           <div class="row">
-            <button class="button" id="inject-decorations" type="button">Show translations &amp; romanizations</button>
+            <button class="button" id="inject-romanizations" type="button">Show romanizations</button>
+            <button class="button" id="inject-translations" type="button">Show translations</button>
           </div>
           <p class="group__hint">
-            Hangs a translation and romanization off every line, the way a provider streams them in after the words
-            land. Switch song or timing to clear them.
+            Each hangs off every line and animates in on its own, the way a provider streams them in after the words
+            land. Toggle them separately or together. Switch song or timing to clear them.
           </p>
 
           <p class="group__note">Or import a file. TTML, LRC, SRT, QRC and plain text, recognised by reading it.</p>

--- a/demo/index.html
+++ b/demo/index.html
@@ -328,6 +328,9 @@
             <button class="button" id="inject-romanizations" type="button">Show romanizations</button>
             <button class="button" id="inject-translations" type="button">Show translations</button>
           </div>
+          <div class="row">
+            <button class="button" id="inject-both" type="button">Show both</button>
+          </div>
           <p class="group__hint">
             Each hangs off every line and animates in on its own, the way a provider streams them in after the words
             land. Toggle them separately or together. Switch song or timing to clear them.

--- a/demo/index.html
+++ b/demo/index.html
@@ -324,6 +324,14 @@
           </fieldset>
           <p class="group__hint" id="timing-hint"></p>
 
+          <div class="row">
+            <button class="button" id="inject-decorations" type="button">Show translations &amp; romanizations</button>
+          </div>
+          <p class="group__hint">
+            Hangs a translation and romanization off every line, the way a provider streams them in after the words
+            land. Switch song or timing to clear them.
+          </p>
+
           <p class="group__note">Or import a file. TTML, LRC, SRT, QRC and plain text, recognised by reading it.</p>
           <div class="row">
             <button class="button" id="lyrics-file" type="button">Choose a file</button>
@@ -411,6 +419,14 @@
             <code>renderer.noteUserScroll()</code> has anything to report. Autoscroll then waits while you read ahead,
             and the renderer asks for the button at the foot of the view. Pause the song first. A view that is
             rendering discounts one scroll a frame against the ones it makes itself, and yours go on that.
+          </p>
+
+          <label class="switch">
+            <input id="animate-decorations" type="checkbox" checked />
+            <span>Animate decoration entry</span>
+          </label>
+          <p class="group__hint">
+            Off makes streamed-in translations and romanizations appear at once instead of sliding the lines apart.
           </p>
         </section>
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -235,12 +235,11 @@ package's stylesheets are yours to load for the same reason.
 `@braccato/core` is the facade and registers nothing. `createLyricsRenderer(options)` returns one
 `LyricsRenderer`: give it lyrics, tick it, and it owns the DOM it builds and every re-measurement
 that DOM needs. `resetPlaybackClock`, `resumeAllAutoscroll`, `injectRomanization` and
-`injectTranslation` are published beside it, for what one instance cannot answer for on its own. Wrap
-those in `renderer.animateDecorationChange` and each hung line floats into place while the lines
-around it slide to make room, rather than the rest of the lyric jumping down; `injectTranslation` and
-`injectRomanization` still animate the floated-in line on their own when called directly.
-`--blyrics-animate-decoration-entry` set to `0` drops both for an instant insert, and reduced-motion
-does the same.
+`injectTranslation` are published beside it, for what one instance cannot answer for on its own. Hang
+one onto a built line and call `renderer.scheduleLyricPositionUpdate` the way you already would to
+catch the layout up: the hung line floats into place while the lines around it slide to make room,
+rather than the rest of the lyric jumping down. `--blyrics-animate-decoration-entry` set to `0` drops
+both for an instant insert, and reduced-motion does the same.
 
 `@braccato/core/element` registers `<braccato-lyrics>`, and `<better-lyrics>` beside it, on import.
 Registration is a side effect, which is why it is entered separately.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -235,9 +235,11 @@ package's stylesheets are yours to load for the same reason.
 `@braccato/core` is the facade and registers nothing. `createLyricsRenderer(options)` returns one
 `LyricsRenderer`: give it lyrics, tick it, and it owns the DOM it builds and every re-measurement
 that DOM needs. `resetPlaybackClock`, `resumeAllAutoscroll`, `injectRomanization` and
-`injectTranslation` are published beside it, for what one instance cannot answer for on its own. A
-line hung on this way reveals itself, growing into place as the lines below slide to make room;
-`--blyrics-animate-decoration-entry` set to `0` drops that for an instant insert, and reduced-motion
+`injectTranslation` are published beside it, for what one instance cannot answer for on its own. Wrap
+those in `renderer.animateDecorationChange` and each hung line floats into place while the lines
+around it slide to make room, rather than the rest of the lyric jumping down; `injectTranslation` and
+`injectRomanization` still animate the floated-in line on their own when called directly.
+`--blyrics-animate-decoration-entry` set to `0` drops both for an instant insert, and reduced-motion
 does the same.
 
 `@braccato/core/element` registers `<braccato-lyrics>`, and `<better-lyrics>` beside it, on import.

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -235,7 +235,10 @@ package's stylesheets are yours to load for the same reason.
 `@braccato/core` is the facade and registers nothing. `createLyricsRenderer(options)` returns one
 `LyricsRenderer`: give it lyrics, tick it, and it owns the DOM it builds and every re-measurement
 that DOM needs. `resetPlaybackClock`, `resumeAllAutoscroll`, `injectRomanization` and
-`injectTranslation` are published beside it, for what one instance cannot answer for on its own.
+`injectTranslation` are published beside it, for what one instance cannot answer for on its own. A
+line hung on this way reveals itself, growing into place as the lines below slide to make room;
+`--blyrics-animate-decoration-entry` set to `0` drops that for an instant insert, and reduced-motion
+does the same.
 
 `@braccato/core/element` registers `<braccato-lyrics>`, and `<better-lyrics>` beside it, on import.
 Registration is a side effect, which is why it is entered separately.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@braccato/core",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Synchronized lyrics renderer with word-by-word animations",
   "type": "module",
   "license": "MIT",

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -23,6 +23,8 @@ import {
   FOOTER_CLASS,
   LINE_CLASS,
   PAUSED_CLASS,
+  ROMANIZED_LYRICS_CLASS,
+  TRANSLATED_LYRICS_CLASS,
   USER_SCROLLING_CLASS,
 } from "./constants";
 import type { AnimationData, LineData, PartData } from "./inject";
@@ -2956,6 +2958,74 @@ export function relayout(engine: AnimationEngineInstance, measureLines: boolean)
 
   engine.wasUserScrolling = true; // trigger rescrolls
   engine.host.debug?.resize();
+}
+
+// -- Decoration slide --------------------------
+
+const DECORATION_SLIDE_MS = 350;
+const DECORATION_SLIDE_EASING = "cubic-bezier(0.25, 1, 0.5, 1)";
+const DECORATION_MIN_SHIFT_PX = 0.5;
+
+function slideElementBy(element: HTMLElement, dy: number): void {
+  element.animate(
+    { translate: [`0 ${dy}px`, "0 0"] },
+    { duration: DECORATION_SLIDE_MS, easing: DECORATION_SLIDE_EASING, composite: "add" }
+  );
+}
+
+function decorationSlideAllowed(engine: AnimationEngineInstance, container: HTMLElement): boolean {
+  if (engine.window.matchMedia(REDUCED_MOTION_QUERY).matches) return false;
+  return (
+    engine.window.getComputedStyle(container).getPropertyValue("--blyrics-animate-decoration-entry").trim() !== "0"
+  );
+}
+
+function decoratorElements(container: HTMLElement): HTMLElement[] {
+  return [
+    ...container.querySelectorAll<HTMLElement>(`.${ROMANIZED_LYRICS_CLASS}`),
+    ...container.querySelectorAll<HTMLElement>(`.${TRANSLATED_LYRICS_CLASS}`),
+  ];
+}
+
+export function animateDecorationChange(
+  engine: AnimationEngineInstance,
+  mutate: () => void,
+  remeasure: () => void
+): void {
+  const container = engine.lyricsContainer;
+  const lineElements = getRenderedLines(engine)
+    .map(line => line.lyricElement)
+    .filter((element): element is HTMLElement => element !== null);
+
+  if (!container || lineElements.length === 0 || !decorationSlideAllowed(engine, container)) {
+    mutate();
+    remeasure();
+    return;
+  }
+
+  const lineTop = new Map(lineElements.map(element => [element, element.getBoundingClientRect().y]));
+  const decoratorTop = new Map(
+    decoratorElements(container).map(element => [element, element.getBoundingClientRect().y])
+  );
+
+  mutate();
+  remeasure();
+
+  const lineShift = new Map<HTMLElement, number>();
+  for (const element of lineElements) {
+    const dy = (lineTop.get(element) ?? 0) - element.getBoundingClientRect().y;
+    lineShift.set(element, dy);
+    if (Math.abs(dy) >= DECORATION_MIN_SHIFT_PX) slideElementBy(element, dy);
+  }
+
+  for (const element of decoratorElements(container)) {
+    const first = decoratorTop.get(element);
+    if (first === undefined) continue;
+    const parentLine = element.closest<HTMLElement>(`.${LINE_CLASS}`);
+    const parentShift = (parentLine ? lineShift.get(parentLine) : 0) ?? 0;
+    const dy = first - element.getBoundingClientRect().y - parentShift;
+    if (Math.abs(dy) >= DECORATION_MIN_SHIFT_PX) slideElementBy(element, dy);
+  }
 }
 
 // -- Debounced Lyrics Update --------------------------

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -2954,6 +2954,9 @@ export function relayout(engine: AnimationEngineInstance, measureLines: boolean)
     const bounds = getRelativeLayoutBounds(lyricsElement, line.lyricElement);
     line.position = bounds.y;
     line.height = bounds.height;
+    line.decorations = new Map(
+      lineDecorators(line.lyricElement).map(element => [element, getRelativeLayoutBounds(lyricsElement, element).y])
+    );
   }
 
   engine.wasUserScrolling = true; // trigger rescrolls
@@ -2980,52 +2983,43 @@ function decorationSlideAllowed(engine: AnimationEngineInstance, container: HTML
   );
 }
 
-function decoratorElements(container: HTMLElement): HTMLElement[] {
+function lineDecorators(lineElement: HTMLElement): HTMLElement[] {
   return [
-    ...container.querySelectorAll<HTMLElement>(`.${ROMANIZED_LYRICS_CLASS}`),
-    ...container.querySelectorAll<HTMLElement>(`.${TRANSLATED_LYRICS_CLASS}`),
+    ...lineElement.querySelectorAll<HTMLElement>(`.${ROMANIZED_LYRICS_CLASS}`),
+    ...lineElement.querySelectorAll<HTMLElement>(`.${TRANSLATED_LYRICS_CLASS}`),
   ];
 }
 
-export function animateDecorationChange(
-  engine: AnimationEngineInstance,
-  mutate: () => void,
-  remeasure: () => void
-): void {
+/**
+ * Snapshots where the lines and their decorators sit now, so the remeasure that follows can slide
+ * each one from there to wherever a streamed decoration just pushed it. Returns null when nothing
+ * should animate, and otherwise a function to call once the new layout is measured: the line rides
+ * its own shift and a decorator rides only the part of its shift its line did not already carry, so
+ * a survivor whose line held still still slides into the gap a removed sibling left.
+ */
+function captureDecorationSlide(engine: AnimationEngineInstance): (() => void) | null {
   const container = engine.lyricsContainer;
-  const lineElements = getRenderedLines(engine)
-    .map(line => line.lyricElement)
-    .filter((element): element is HTMLElement => element !== null);
+  if (!container || !decorationSlideAllowed(engine, container)) return null;
 
-  if (!container || lineElements.length === 0 || !decorationSlideAllowed(engine, container)) {
-    mutate();
-    remeasure();
-    return;
-  }
+  const before = engine.lines.map(line => ({
+    line,
+    position: line.position,
+    decorations: new Map(line.decorations),
+  }));
 
-  const lineTop = new Map(lineElements.map(element => [element, element.getBoundingClientRect().y]));
-  const decoratorTop = new Map(
-    decoratorElements(container).map(element => [element, element.getBoundingClientRect().y])
-  );
+  return () => {
+    for (const { line, position, decorations } of before) {
+      const lineShift = position - line.position;
+      if (Math.abs(lineShift) >= DECORATION_MIN_SHIFT_PX) slideElementBy(line.lyricElement, lineShift);
 
-  mutate();
-  remeasure();
-
-  const lineShift = new Map<HTMLElement, number>();
-  for (const element of lineElements) {
-    const dy = (lineTop.get(element) ?? 0) - element.getBoundingClientRect().y;
-    lineShift.set(element, dy);
-    if (Math.abs(dy) >= DECORATION_MIN_SHIFT_PX) slideElementBy(element, dy);
-  }
-
-  for (const element of decoratorElements(container)) {
-    const first = decoratorTop.get(element);
-    if (first === undefined) continue;
-    const parentLine = element.closest<HTMLElement>(`.${LINE_CLASS}`);
-    const parentShift = (parentLine ? lineShift.get(parentLine) : 0) ?? 0;
-    const dy = first - element.getBoundingClientRect().y - parentShift;
-    if (Math.abs(dy) >= DECORATION_MIN_SHIFT_PX) slideElementBy(element, dy);
-  }
+      for (const [element, was] of decorations) {
+        const now = line.decorations.get(element);
+        if (now === undefined) continue;
+        const shift = was - now - lineShift;
+        if (Math.abs(shift) >= DECORATION_MIN_SHIFT_PX) slideElementBy(element, shift);
+      }
+    }
+  };
 }
 
 // -- Debounced Lyrics Update --------------------------
@@ -3078,7 +3072,9 @@ export function scheduleLyricPositionUpdate(
   engine.pendingLyricsUpdateFrame = engine.window.requestAnimationFrame(() => {
     engine.pendingLyricsUpdateFrame = null;
     const isRendering = isViewRendering();
+    const playSlide = isRendering ? captureDecorationSlide(engine) : null;
     relayout(engine, isRendering);
+    playSlide?.();
     if (!isRendering) return;
     retick();
   });

--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -117,6 +117,7 @@ export type LineData = {
   isSelected: boolean;
   height: number;
   position: number;
+  decorations: Map<HTMLElement, number>;
 } & AnimationData;
 
 type SpaceToken = {
@@ -171,6 +172,7 @@ export function newLineData(lyricElement: HTMLElement, startTimeMs: number, dura
     isSelected: false,
     height: -1,
     position: -1,
+    decorations: new Map(),
     animations: [],
   };
 }

--- a/packages/core/src/renderer.selfcheck.ts
+++ b/packages/core/src/renderer.selfcheck.ts
@@ -1760,37 +1760,38 @@ slidingLines[0].appendChild(survivingDecoration);
 slidingRenderer.relayout();
 
 const measurementsBeforeSlide = sliding.measurements;
-let slidingMutations = 0;
 
-slidingRenderer.animateDecorationChange(() => {
-  slidingMutations += 1;
-  slidingLines[1].offsetTop = LINE_PITCH_PX - 40;
-  slidingLines[2].offsetTop = 2 * LINE_PITCH_PX - 40;
-  survivingDecoration.offsetTop = LINE_HEIGHT_PX;
-});
-
-assert.equal(
-  slidingMutations,
-  1,
-  "Given a decoration change, When it runs, Then the mutation it wraps runs exactly once"
+slidingLines[1].offsetTop = LINE_PITCH_PX - 40;
+slidingLines[2].offsetTop = 2 * LINE_PITCH_PX - 40;
+survivingDecoration.offsetTop = LINE_HEIGHT_PX;
+slidingRenderer.scheduleLyricPositionUpdate(
+  () => true,
+  () => {}
 );
+
+const slidingFrame = sliding.fakeWindow.requestedFrames.at(-1);
+assert.ok(
+  slidingFrame,
+  "Given a streamed decoration, When the view is asked to catch up, Then it queues a frame rather than sliding under whoever told it"
+);
+slidingFrame(0);
 
 assert.equal(
   sliding.measurements,
   measurementsBeforeSlide + 1,
-  "Given a decoration change, When it runs, Then the lines it moved are measured again"
+  "Given the frame a streamed decoration queued, When it runs, Then the lines it moved are measured again"
 );
 
 assert.deepEqual(
   slidingLines.map(line => line.animations.length),
   [0, 1, 1],
-  "Given a decoration that moved the lines below it, When the change runs, Then those lines slide and the one whose top held does not"
+  "Given a decoration that moved the lines below it, When the frame runs, Then those lines slide and the one whose top held does not"
 );
 
 assert.equal(
   survivingDecoration.animations.length,
   1,
-  "Given a decoration that moved within its own line, When the change runs, Then it slides to its new place rather than snapping under the line's own slide"
+  "Given a decoration that moved within its own line, When the frame runs, Then it slides to its new place rather than snapping under the line's own slide"
 );
 
 slidingRenderer.destroy();
@@ -1824,29 +1825,30 @@ instantLines.forEach((line, index) => {
 instantRenderer.relayout();
 
 const measurementsBeforeInstant = instant.measurements;
-let instantMutations = 0;
 
-instantRenderer.animateDecorationChange(() => {
-  instantMutations += 1;
-  instantLines[1].offsetTop = LINE_PITCH_PX - 40;
-});
-
-assert.equal(
-  instantMutations,
-  1,
-  "Given the slide switched off, When a decoration change runs, Then its mutation still runs once"
+instantLines[1].offsetTop = LINE_PITCH_PX - 40;
+instantRenderer.scheduleLyricPositionUpdate(
+  () => true,
+  () => {}
 );
+
+const instantFrame = instant.fakeWindow.requestedFrames.at(-1);
+assert.ok(
+  instantFrame,
+  "Given a streamed decoration with the slide off, When the view is asked to catch up, Then it still queues a frame"
+);
+instantFrame(0);
 
 assert.equal(
   instant.measurements,
   measurementsBeforeInstant + 1,
-  "Given the slide switched off, When a decoration change runs, Then the lines are still measured again"
+  "Given the slide switched off, When the frame runs, Then the lines are still measured again"
 );
 
 assert.deepEqual(
   instantLines.map(line => line.animations.length),
   [0, 0, 0],
-  "Given the slide switched off, When a decoration change moves the lines, Then none of them slides"
+  "Given the slide switched off, When the frame moves the lines, Then none of them slides"
 );
 
 instantRenderer.destroy();

--- a/packages/core/src/renderer.selfcheck.ts
+++ b/packages/core/src/renderer.selfcheck.ts
@@ -1,5 +1,5 @@
 import { strict as assert } from "node:assert";
-import { CUSTOM_THEME_STYLE_ID, LINE_CLASS, USER_SCROLLING_CLASS } from "./constants";
+import { CUSTOM_THEME_STYLE_ID, LINE_CLASS, ROMANIZED_LYRICS_CLASS, USER_SCROLLING_CLASS } from "./constants";
 import type { LineData } from "./inject";
 import { createLyricsRenderer, withHostDefaults } from "./renderer";
 import { asDocument, asElement, asFakeAnimation, asFakeNode, FakeDocument, FakeNode } from "./selfcheck/fakeDom";
@@ -1725,6 +1725,132 @@ assert.deepEqual(
   "Given a destroyed view that created the stylesheet, When the document is read, Then it took the element with it"
 );
 
+// -- A streamed decoration slides the lines it moved, and its neighbours within a line -----------
+
+const { fixture: sliding, host: slidingHost } = newViewFixture({
+  ...SCROLL_ANIMATION_OFF,
+  "--blyrics-animate-decoration-entry": "1",
+});
+const slidingRenderer = createLyricsRenderer({
+  document: asDocument(sliding.fakeDocument),
+  window: asWindow(sliding.fakeWindow),
+  mount: asElement<HTMLElement>(sliding.mount),
+  host: slidingHost,
+});
+
+slidingRenderer.setLyrics(SYNCED_LYRICS);
+
+const slidingContainer = slidingRenderer.container;
+assert.ok(
+  slidingContainer !== null,
+  "Given built lyrics, When the view is asked, Then it holds the container it built"
+);
+
+const slidingLines = asFakeNode(slidingContainer).childNodes.filter(child => child.classList.contains(LINE_CLASS));
+slidingLines.forEach((line, index) => {
+  line.offsetTop = index * LINE_PITCH_PX;
+  line.offsetHeight = LINE_HEIGHT_PX;
+});
+
+const survivingDecoration = sliding.fakeDocument.createElement("div");
+survivingDecoration.classList.add(ROMANIZED_LYRICS_CLASS);
+survivingDecoration.offsetTop = LINE_HEIGHT_PX + 40;
+slidingLines[0].appendChild(survivingDecoration);
+
+slidingRenderer.relayout();
+
+const measurementsBeforeSlide = sliding.measurements;
+let slidingMutations = 0;
+
+slidingRenderer.animateDecorationChange(() => {
+  slidingMutations += 1;
+  slidingLines[1].offsetTop = LINE_PITCH_PX - 40;
+  slidingLines[2].offsetTop = 2 * LINE_PITCH_PX - 40;
+  survivingDecoration.offsetTop = LINE_HEIGHT_PX;
+});
+
+assert.equal(
+  slidingMutations,
+  1,
+  "Given a decoration change, When it runs, Then the mutation it wraps runs exactly once"
+);
+
+assert.equal(
+  sliding.measurements,
+  measurementsBeforeSlide + 1,
+  "Given a decoration change, When it runs, Then the lines it moved are measured again"
+);
+
+assert.deepEqual(
+  slidingLines.map(line => line.animations.length),
+  [0, 1, 1],
+  "Given a decoration that moved the lines below it, When the change runs, Then those lines slide and the one whose top held does not"
+);
+
+assert.equal(
+  survivingDecoration.animations.length,
+  1,
+  "Given a decoration that moved within its own line, When the change runs, Then it slides to its new place rather than snapping under the line's own slide"
+);
+
+slidingRenderer.destroy();
+
+// -- The same change, with the animation switched off, only re-measures --------------------------
+
+const { fixture: instant, host: instantHost } = newViewFixture({
+  ...SCROLL_ANIMATION_OFF,
+  "--blyrics-animate-decoration-entry": "0",
+});
+const instantRenderer = createLyricsRenderer({
+  document: asDocument(instant.fakeDocument),
+  window: asWindow(instant.fakeWindow),
+  mount: asElement<HTMLElement>(instant.mount),
+  host: instantHost,
+});
+
+instantRenderer.setLyrics(SYNCED_LYRICS);
+
+const instantContainer = instantRenderer.container;
+assert.ok(
+  instantContainer !== null,
+  "Given built lyrics, When the view is asked, Then it holds the container it built"
+);
+
+const instantLines = asFakeNode(instantContainer).childNodes.filter(child => child.classList.contains(LINE_CLASS));
+instantLines.forEach((line, index) => {
+  line.offsetTop = index * LINE_PITCH_PX;
+  line.offsetHeight = LINE_HEIGHT_PX;
+});
+instantRenderer.relayout();
+
+const measurementsBeforeInstant = instant.measurements;
+let instantMutations = 0;
+
+instantRenderer.animateDecorationChange(() => {
+  instantMutations += 1;
+  instantLines[1].offsetTop = LINE_PITCH_PX - 40;
+});
+
+assert.equal(
+  instantMutations,
+  1,
+  "Given the slide switched off, When a decoration change runs, Then its mutation still runs once"
+);
+
+assert.equal(
+  instant.measurements,
+  measurementsBeforeInstant + 1,
+  "Given the slide switched off, When a decoration change runs, Then the lines are still measured again"
+);
+
+assert.deepEqual(
+  instantLines.map(line => line.animations.length),
+  [0, 0, 0],
+  "Given the slide switched off, When a decoration change moves the lines, Then none of them slides"
+);
+
+instantRenderer.destroy();
+
 const drivenFixtures = [
   panel,
   faceless,
@@ -1738,6 +1864,8 @@ const drivenFixtures = [
   unsynced,
   themed,
   shared,
+  sliding,
+  instant,
 ];
 
 assert.equal(

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -12,6 +12,7 @@
 
 import { CUSTOM_THEME_STYLE_ID } from "./constants";
 import {
+  animateDecorationChange as animateEngineDecorationChange,
   clearLyrics,
   clearOnScreenLyrics as clearEngineOnScreenLyrics,
   clearStyleCaches as clearEngineStyleCaches,
@@ -321,6 +322,13 @@ export function createLyricsRenderer(rendererOptions: LyricsRendererOptions): Ly
     relayout(measureLines = true) {
       if (isDestroyed) return;
       measure(measureLines);
+    },
+    animateDecorationChange(mutate) {
+      if (isDestroyed) {
+        mutate();
+        return;
+      }
+      animateEngineDecorationChange(engine, mutate, measure);
     },
     clear() {
       if (isDestroyed) return;

--- a/packages/core/src/renderer.ts
+++ b/packages/core/src/renderer.ts
@@ -12,7 +12,6 @@
 
 import { CUSTOM_THEME_STYLE_ID } from "./constants";
 import {
-  animateDecorationChange as animateEngineDecorationChange,
   clearLyrics,
   clearOnScreenLyrics as clearEngineOnScreenLyrics,
   clearStyleCaches as clearEngineStyleCaches,
@@ -322,13 +321,6 @@ export function createLyricsRenderer(rendererOptions: LyricsRendererOptions): Ly
     relayout(measureLines = true) {
       if (isDestroyed) return;
       measure(measureLines);
-    },
-    animateDecorationChange(mutate) {
-      if (isDestroyed) {
-        mutate();
-        return;
-      }
-      animateEngineDecorationChange(engine, mutate, measure);
     },
     clear() {
       if (isDestroyed) return;

--- a/packages/core/src/styles/lyrics.css
+++ b/packages/core/src/styles/lyrics.css
@@ -184,6 +184,8 @@
 
 .blyrics--translated,
 .blyrics--romanized {
+	animation: blyrics-decoration-in calc(var(--blyrics-animate-decoration-entry) * 0.35s)
+		cubic-bezier(0.25, 1, 0.5, 1) both;
 	color: var(--blyrics-translated-color);
 	display: block;
 	font-family: var(--blyrics-translated-font-family);
@@ -195,6 +197,16 @@
 	text-align: inherit;
 	unicode-bidi: plaintext;
 	white-space: normal;
+}
+
+/* A streamed-in decorator floats up into place. Compositor-only (transform + opacity), so it never
+   clips its own text or touches layout; the host slides the lines around it (a FLIP on the lines'
+   translate) to make room. */
+@keyframes blyrics-decoration-in {
+	from {
+		opacity: 0;
+		transform: translateY(-0.4em);
+	}
 }
 
 .blyrics--romanized {

--- a/packages/core/src/styles/lyrics.css
+++ b/packages/core/src/styles/lyrics.css
@@ -199,9 +199,6 @@
 	white-space: normal;
 }
 
-/* A streamed-in decorator floats up into place. Compositor-only (transform + opacity), so it never
-   clips its own text or touches layout; the host slides the lines around it (a FLIP on the lines'
-   translate) to make room. */
 @keyframes blyrics-decoration-in {
 	from {
 		opacity: 0;

--- a/packages/core/src/styles/variables.css
+++ b/packages/core/src/styles/variables.css
@@ -63,6 +63,7 @@
 	--blyrics-animate-highlight-fade: 1;
 	--blyrics-animate-scroll: 1;
 	--blyrics-animate-instrumental: 1;
+	--blyrics-animate-decoration-entry: 1;
 
 	--blyrics-loader-transition-duration: 0.6s;
 	--blyrics-loader-transition-easing: cubic-bezier(0.22, 1, 0.36, 1);
@@ -176,6 +177,7 @@
 		--blyrics-animate-line-scale: 0;
 		--blyrics-animate-word-wobble: 0;
 		--blyrics-animate-instrumental: 0;
+		--blyrics-animate-decoration-entry: 0;
 
 		--blyrics-scale: 1;
 		--blyrics-active-scale: 1;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -157,6 +157,14 @@ export interface LyricsRenderer {
    */
   relayout(measureLines?: boolean): void;
   /**
+   * Runs `mutate`, which hangs translations or romanizations onto the built lines or takes them off,
+   * then slides the lines and their surviving decorators from where they were to where the change put
+   * them, so a streamed-in line eases the rest of the lyric down rather than jumping it. Re-measures
+   * either way. Honours reduced motion and `--blyrics-animate-decoration-entry`: when either is off it
+   * runs `mutate` and re-measures with no slide.
+   */
+  animateDecorationChange(mutate: () => void): void;
+  /**
    * Drops the song and the DOM built for it. The renderer built that DOM, so it takes it away again.
    */
   clear(): void;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -157,14 +157,6 @@ export interface LyricsRenderer {
    */
   relayout(measureLines?: boolean): void;
   /**
-   * Runs `mutate`, which hangs translations or romanizations onto the built lines or takes them off,
-   * then slides the lines and their surviving decorators from where they were to where the change put
-   * them, so a streamed-in line eases the rest of the lyric down rather than jumping it. Re-measures
-   * either way. Honours reduced motion and `--blyrics-animate-decoration-entry`: when either is off it
-   * runs `mutate` and re-measures with no slide.
-   */
-  animateDecorationChange(mutate: () => void): void;
-  /**
    * Drops the song and the DOM built for it. The renderer built that DOM, so it takes it away again.
    */
   clear(): void;
@@ -193,9 +185,14 @@ export interface LyricsRenderer {
    */
   clearOnScreenLyrics(): boolean;
   /**
-   * Re-measures the lines on the next frame and renders the view again against them. The predicate
-   * is the caller's half of whether that frame does anything, and only that half: whether the lines
-   * are on the screen to be measured at all is the renderer's own question, and it asks it itself.
+   * Re-measures the lines on the next frame and renders the view again against them. This is the door
+   * a consumer knocks on after streaming in a translation or romanization, and it is what slides the
+   * lines the new decoration moved from where they were to where it put them, together with any
+   * surviving decorator that shifted within its own line, so the rest of the lyric eases down rather
+   * than jumping. The slide honours reduced motion and `--blyrics-animate-decoration-entry`; with
+   * either off the lines are re-measured with no slide. The predicate is the caller's half of whether
+   * that frame does anything, and only that half: whether the lines are on the screen to be measured
+   * at all is the renderer's own question, and it asks it itself.
    *
    * @param isTicking - Whether whoever drives this view is still driving it, asked on the frame
    *   rather than now. A driver that has stopped is one whose lines may no longer be rendered, and

--- a/tooling/build-package.ts
+++ b/tooling/build-package.ts
@@ -111,9 +111,8 @@ cpSync(join(packageDir, "LICENSE"), join(outDir, "LICENSE"));
 
 // Same shape as the exports check above, one consumer further out: the page in demo/ and the README
 // copied in beside this artifact both document the API by name, so the emit is the moment to find
-// out whether they still describe it. The version travels with them, because it is the manifest's
-// now rather than something this emit writes.
-checkApiDocs(outDir, manifest.version);
+// out whether they still describe it.
+checkApiDocs(outDir);
 
 console.log(
   `Emitted @braccato/core ${manifest.version} to packages/core/dist: ${emitted.length} files, ${stylesheets.length} stylesheets`

--- a/tooling/check-api-docs.ts
+++ b/tooling/check-api-docs.ts
@@ -19,7 +19,6 @@ import {
   CLASS_NAMES,
   CUSTOM_PROPERTIES,
   EVENTS,
-  PACKAGE,
   PROPERTIES,
   STYLESHEETS,
   THEME_SETTINGS,
@@ -36,8 +35,6 @@ const SETTING_SOURCES = ["engine.js", "inject.js"];
 
 /** The artifact both documents are held against, read once because both ask it the same questions. */
 interface EmittedApi {
-  /** The manifest's, handed in: the emit writes code and stylesheets, not a version. */
-  version: string;
   members: Set<string>;
   constants: Map<string, string>;
   elementSource: string;
@@ -96,9 +93,8 @@ function readStylesheets(packageDir: string): Map<string, string> {
   return sheets;
 }
 
-function readEmittedApi(packageDir: string, version: string): EmittedApi {
+function readEmittedApi(packageDir: string): EmittedApi {
   return {
-    version,
     members: readElementMembers(packageDir),
     constants: readClassNameConstants(packageDir),
     elementSource: readFileSync(join(packageDir, "element.js"), "utf8"),
@@ -121,10 +117,6 @@ function quotesEvery(names: string[], text: string): string[] {
 
 function checkDemoPage(emitted: EmittedApi): { failures: string[]; checked: number } {
   const failures: string[] = [];
-
-  if (emitted.version !== PACKAGE.version) {
-    failures.push(`the page says version ${PACKAGE.version}, the artifact says ${emitted.version}`);
-  }
 
   for (const { key } of THEME_SETTINGS) {
     // Most keys are written out whole; the line scroll ones are derived from a custom property name,
@@ -302,8 +294,8 @@ function checkReadme(packageDir: string, emitted: EmittedApi): { failures: strin
 
 // -- Both documents --------------------------------------------
 
-export function checkApiDocs(packageDir: string, version: string): void {
-  const emitted = readEmittedApi(packageDir, version);
+export function checkApiDocs(packageDir: string): void {
+  const emitted = readEmittedApi(packageDir);
   const demoPage = checkDemoPage(emitted);
   const readme = checkReadme(packageDir, emitted);
 


### PR DESCRIPTION
## Overview

Translations and romanizations stream in after the lines already render, so today they pop in and shove everything below them down in one jump. Now each one floats in on a transform and opacity fade, kept off the layout path so nothing clips or stutters, and the demo gets a control to trigger it with the lines sliding to make room. A theme toggle and reduced motion both turn it off.

Built on the idea and work of @ramansg in better-lyrics/better-lyrics#543.
