### PR TITLE
feat(provider-blyrics): add unison, binimum and portato providers

### DIFF
--- a/packages/provider-blyrics/README.md
+++ b/packages/provider-blyrics/README.md
@@ -17,7 +17,7 @@ const chain = new ProviderChain();
 chain.register("lrclib-synced", createLRCLibSyncedProvider());
 
 const result = await chain.fetchLyrics(
-  { song: "Title", artist: "Artist", duration: 240000 },
+  { song: "Title", artist: "Artist", duration: 240 },
   { signal: abortController.signal }
 );
 ```
@@ -30,7 +30,19 @@ import {
   createLRCLibSyncedProvider,
   createLRCLibPlainProvider,
   createLegatoProvider,
+  createBinimumProvider,
+  createPortatoProvider,
+  createUnisonProvider,
 } from "@braccato/provider-blyrics";
+```
+
+`createUnisonProvider` matches on `videoId`, so pass it on the context when you have one:
+
+```typescript
+const result = await chain.fetchLyrics(
+  { song: "Title", artist: "Artist", duration: 240, videoId: "dQw4w9WgXcQ" },
+  { signal: abortController.signal }
+);
 ```
 
 ## Validation

--- a/packages/provider-blyrics/package.json
+++ b/packages/provider-blyrics/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@braccato/provider-blyrics",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Lyrics provider chain with priority and validation",
 	"type": "module",
 	"license": "MIT",

--- a/packages/provider-blyrics/src/__tests__/providers.test.ts
+++ b/packages/provider-blyrics/src/__tests__/providers.test.ts
@@ -1,0 +1,307 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createBinimumProvider } from "../providers/binimum.js";
+import { createBLyricsProvider } from "../providers/blyrics.js";
+import { createLegatoProvider } from "../providers/legato.js";
+import { createLRCLibPlainProvider, createLRCLibSyncedProvider } from "../providers/lrclib.js";
+import { createPortatoProvider } from "../providers/portato.js";
+import { createUnisonProvider } from "../providers/unison.js";
+import type { ProviderContext } from "../types.js";
+
+const TTML = `<tt xmlns="http://www.w3.org/ns/ttml" xml:lang="en">
+	<body dur="30s">
+		<div>
+			<p begin="5s" end="10s" key="l1">
+				<span begin="5s" end="7s"><span>Hello </span></span>
+				<span begin="7s" end="10s"><span>world</span></span>
+			</p>
+		</div>
+	</body>
+</tt>`;
+
+const QRC = `[1000,2000]First(1000,1000) line(2000,1000)
+[4000,2000]Second(4000,1000) line(5000,1000)`;
+
+const LRC = `[00:12.50]Hello world
+[00:15.00]Second line`;
+
+const PLAIN = "Hello world\nSecond line";
+
+function makeCtx(overrides: Partial<ProviderContext> = {}): ProviderContext {
+	return {
+		song: "Paradise",
+		artist: "Coldplay",
+		album: "Mylo Xyloto",
+		duration: 279,
+		signal: new AbortController().signal,
+		...overrides,
+	};
+}
+
+type Route = (url: string) => { ok: boolean; status?: number; json?: unknown; text?: string };
+
+function stubFetch(route: Route) {
+	const calls: string[] = [];
+	vi.stubGlobal("fetch", async (input: string | URL) => {
+		const url = input.toString();
+		calls.push(url);
+		const r = route(url);
+		return {
+			ok: r.ok,
+			status: r.status ?? (r.ok ? 200 : 500),
+			json: async () => r.json,
+			text: async () => r.text ?? "",
+		} as Response;
+	});
+	return calls;
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+describe("createPortatoProvider", () => {
+	it("parses QRC into word-synced lyrics with attribution", async () => {
+		stubFetch(() => ({ ok: true, json: { lyrics: QRC } }));
+
+		const result = await createPortatoProvider()(makeCtx());
+
+		expect(result).not.toBeNull();
+		expect(result!.lyrics!.some((l) => !l.isInstrumental)).toBe(true);
+		expect(result!.source).toBe("Better Lyrics Portato");
+		expect(result!.sourceHref).toBe("https://boidu.dev/");
+		expect(result!.musicVideoSynced).toBe(false);
+		expect(result!.cacheAllowed).toBe(true);
+	});
+
+	it("sends song, artist, duration, and album as s/a/d/al", async () => {
+		const calls = stubFetch(() => ({ ok: true, json: { lyrics: QRC } }));
+
+		await createPortatoProvider()(makeCtx());
+
+		const url = new URL(calls[0]);
+		expect(url.searchParams.get("s")).toBe("Paradise");
+		expect(url.searchParams.get("a")).toBe("Coldplay");
+		expect(url.searchParams.get("d")).toBe("279");
+		expect(url.searchParams.get("al")).toBe("Mylo Xyloto");
+	});
+
+	it("returns null when the response carries an error", async () => {
+		stubFetch(() => ({ ok: true, json: { error: "not found" } }));
+		expect(await createPortatoProvider()(makeCtx())).toBeNull();
+	});
+
+	it("returns null on a non-ok response", async () => {
+		stubFetch(() => ({ ok: false, status: 500 }));
+		expect(await createPortatoProvider()(makeCtx())).toBeNull();
+	});
+});
+
+describe("createBinimumProvider", () => {
+	it("searches, then fetches the first result's TTML", async () => {
+		const calls = stubFetch((url) =>
+			url.includes(".ttml")
+				? { ok: true, text: TTML }
+				: {
+						ok: true,
+						json: {
+							total: 1,
+							results: [{ timing_type: "word", lyricsUrl: "https://lyrics-storage.binimum.org/X.ttml" }],
+						},
+					},
+		);
+
+		const result = await createBinimumProvider()(makeCtx());
+
+		expect(result).not.toBeNull();
+		expect(result!.lyrics!.length).toBeGreaterThan(0);
+		expect(result!.source).toBe("BiniLyrics");
+		expect(result!.sourceHref).toBe("https://lyrics-api.binimum.org/");
+		expect(calls[1]).toBe("https://lyrics-storage.binimum.org/X.ttml");
+	});
+
+	it("searches by track, artist, duration, and album", async () => {
+		const calls = stubFetch((url) =>
+			url.includes(".ttml")
+				? { ok: true, text: TTML }
+				: { ok: true, json: { results: [{ lyricsUrl: "https://lyrics-storage.binimum.org/X.ttml" }] } },
+		);
+
+		await createBinimumProvider()(makeCtx());
+
+		const url = new URL(calls[0]);
+		expect(url.searchParams.get("track")).toBe("Paradise");
+		expect(url.searchParams.get("artist")).toBe("Coldplay");
+		expect(url.searchParams.get("duration")).toBe("279");
+		expect(url.searchParams.get("album")).toBe("Mylo Xyloto");
+	});
+
+	it("returns null when the search has no results", async () => {
+		stubFetch(() => ({ ok: true, json: { total: 0, results: [] } }));
+		expect(await createBinimumProvider()(makeCtx())).toBeNull();
+	});
+
+	it("returns null when the first result has no lyricsUrl", async () => {
+		stubFetch(() => ({ ok: true, json: { results: [{ timing_type: "line" }] } }));
+		expect(await createBinimumProvider()(makeCtx())).toBeNull();
+	});
+
+	it("returns null when the TTML fetch fails", async () => {
+		stubFetch((url) =>
+			url.includes(".ttml")
+				? { ok: false, status: 404 }
+				: { ok: true, json: { results: [{ lyricsUrl: "https://lyrics-storage.binimum.org/X.ttml" }] } },
+		);
+		expect(await createBinimumProvider()(makeCtx())).toBeNull();
+	});
+});
+
+describe("createUnisonProvider", () => {
+	it("parses TTML when format is ttml", async () => {
+		stubFetch(() => ({ ok: true, json: { data: { format: "ttml", syncType: "richsync", lyrics: TTML } } }));
+
+		const result = await createUnisonProvider()(makeCtx({ videoId: "abc123" }));
+
+		expect(result).not.toBeNull();
+		expect(result!.lyrics!.length).toBeGreaterThan(0);
+		expect(result!.source).toBe("Unison");
+		expect(result!.cacheAllowed).toBe(false);
+	});
+
+	it("parses LRC when format is lrc", async () => {
+		stubFetch(() => ({ ok: true, json: { data: { format: "lrc", lyrics: LRC } } }));
+
+		const result = await createUnisonProvider()(makeCtx({ videoId: "abc123" }));
+
+		expect(result!.lyrics!.map((l) => l.words)).toContain("Hello world");
+	});
+
+	it("parses plain text when format is plain", async () => {
+		stubFetch(() => ({ ok: true, json: { data: { format: "plain", lyrics: PLAIN } } }));
+
+		const result = await createUnisonProvider()(makeCtx({ videoId: "abc123" }));
+
+		expect(result!.lyrics!.length).toBe(2);
+	});
+
+	it("sends videoId as v alongside song/artist/duration/album", async () => {
+		const calls = stubFetch(() => ({ ok: true, json: { data: { format: "lrc", lyrics: LRC } } }));
+
+		await createUnisonProvider()(makeCtx({ videoId: "abc123" }));
+
+		const url = new URL(calls[0]);
+		expect(url.searchParams.get("v")).toBe("abc123");
+		expect(url.searchParams.get("song")).toBe("Paradise");
+		expect(url.searchParams.get("artist")).toBe("Coldplay");
+		expect(url.searchParams.get("duration")).toBe("279");
+		expect(url.searchParams.get("album")).toBe("Mylo Xyloto");
+	});
+
+	it("returns null on 404", async () => {
+		stubFetch(() => ({ ok: false, status: 404 }));
+		expect(await createUnisonProvider()(makeCtx({ videoId: "abc123" }))).toBeNull();
+	});
+
+	it("returns null when data has no format or lyrics", async () => {
+		stubFetch(() => ({ ok: true, json: { data: {} } }));
+		expect(await createUnisonProvider()(makeCtx({ videoId: "abc123" }))).toBeNull();
+	});
+});
+
+describe("createBLyricsProvider", () => {
+	it("parses TTML and carries the language", async () => {
+		stubFetch(() => ({ ok: true, json: { ttml: TTML, lang: "en" } }));
+
+		const result = await createBLyricsProvider()(makeCtx());
+
+		expect(result!.lyrics!.length).toBeGreaterThan(0);
+		expect(result!.language).toBe("en");
+		expect(result!.source).toBe("boidu.dev");
+	});
+
+	it("sends s/a/d/al params", async () => {
+		const calls = stubFetch(() => ({ ok: true, json: { ttml: TTML } }));
+
+		await createBLyricsProvider()(makeCtx());
+
+		const url = new URL(calls[0]);
+		expect(url.searchParams.get("s")).toBe("Paradise");
+		expect(url.searchParams.get("a")).toBe("Coldplay");
+		expect(url.searchParams.get("d")).toBe("279");
+		expect(url.searchParams.get("al")).toBe("Mylo Xyloto");
+	});
+
+	it("returns null when the response has no ttml", async () => {
+		stubFetch(() => ({ ok: true, json: {} }));
+		expect(await createBLyricsProvider()(makeCtx())).toBeNull();
+	});
+
+	it("returns null on a non-ok response", async () => {
+		stubFetch(() => ({ ok: false, status: 500 }));
+		expect(await createBLyricsProvider()(makeCtx())).toBeNull();
+	});
+});
+
+describe("createLegatoProvider", () => {
+	it("parses LRC into line-synced lyrics", async () => {
+		stubFetch(() => ({ ok: true, json: { lyrics: LRC } }));
+
+		const result = await createLegatoProvider()(makeCtx());
+
+		expect(result!.lyrics!.map((l) => l.words)).toContain("Hello world");
+		expect(result!.source).toBe("Better Lyrics Legato");
+	});
+
+	it("returns null when the response has no lyrics", async () => {
+		stubFetch(() => ({ ok: true, json: {} }));
+		expect(await createLegatoProvider()(makeCtx())).toBeNull();
+	});
+});
+
+describe("createLRCLibSyncedProvider", () => {
+	it("parses syncedLyrics and sends the Lrclib-Client header", async () => {
+		let sentHeader: string | undefined;
+		vi.stubGlobal("fetch", async (_input: string | URL, init?: RequestInit) => {
+			sentHeader = (init?.headers as Record<string, string>)?.["Lrclib-Client"];
+			return { ok: true, status: 200, json: async () => ({ syncedLyrics: LRC }) } as Response;
+		});
+
+		const result = await createLRCLibSyncedProvider()(makeCtx());
+
+		expect(result!.lyrics!.map((l) => l.words)).toContain("Hello world");
+		expect(result!.source).toBe("LRCLib");
+		expect(sentHeader).toBeTruthy();
+	});
+
+	it("sends lrclib query params", async () => {
+		const calls = stubFetch(() => ({ ok: true, json: { syncedLyrics: LRC } }));
+
+		await createLRCLibSyncedProvider()(makeCtx());
+
+		const url = new URL(calls[0]);
+		expect(url.searchParams.get("track_name")).toBe("Paradise");
+		expect(url.searchParams.get("artist_name")).toBe("Coldplay");
+		expect(url.searchParams.get("album_name")).toBe("Mylo Xyloto");
+		expect(url.searchParams.get("duration")).toBe("279");
+	});
+
+	it("returns null when there are no synced lyrics", async () => {
+		stubFetch(() => ({ ok: true, json: { plainLyrics: PLAIN } }));
+		expect(await createLRCLibSyncedProvider()(makeCtx())).toBeNull();
+	});
+});
+
+describe("createLRCLibPlainProvider", () => {
+	it("parses plainLyrics with cacheAllowed false", async () => {
+		stubFetch(() => ({ ok: true, json: { plainLyrics: PLAIN } }));
+
+		const result = await createLRCLibPlainProvider()(makeCtx());
+
+		expect(result!.lyrics!.length).toBe(2);
+		expect(result!.cacheAllowed).toBe(false);
+	});
+
+	it("returns null when there are no plain lyrics", async () => {
+		stubFetch(() => ({ ok: true, json: { syncedLyrics: LRC } }));
+		expect(await createLRCLibPlainProvider()(makeCtx())).toBeNull();
+	});
+});

--- a/packages/provider-blyrics/src/index.ts
+++ b/packages/provider-blyrics/src/index.ts
@@ -14,4 +14,7 @@ export {
 	type LRCLibProviderOptions,
 } from "./providers/lrclib.js";
 export { createLegatoProvider, type LegatoProviderOptions } from "./providers/legato.js";
+export { createBinimumProvider, type BinimumProviderOptions } from "./providers/binimum.js";
+export { createPortatoProvider, type PortatoProviderOptions } from "./providers/portato.js";
+export { createUnisonProvider, type UnisonProviderOptions } from "./providers/unison.js";
 export { stringSimilarity, createSimilarityValidator } from "./validation.js";

--- a/packages/provider-blyrics/src/providers/binimum.ts
+++ b/packages/provider-blyrics/src/providers/binimum.ts
@@ -1,0 +1,48 @@
+import { TTMLParser } from "@braccato/parsers";
+import type { LyricSourceResult, ProviderFn } from "../types.js";
+
+const DEFAULT_API_URL = "https://lyrics-api.binimum.org/";
+
+interface BinimumResult {
+	timing_type?: string;
+	lyricsUrl?: string;
+}
+
+export interface BinimumProviderOptions {
+	apiUrl?: string;
+	timeout?: number;
+}
+
+export function createBinimumProvider(options: BinimumProviderOptions = {}): ProviderFn {
+	const { apiUrl = DEFAULT_API_URL, timeout = 10000 } = options;
+
+	return async (ctx): Promise<LyricSourceResult | null> => {
+		const signal = () => AbortSignal.any([ctx.signal, AbortSignal.timeout(timeout)]);
+
+		const searchUrl = new URL(apiUrl);
+		searchUrl.searchParams.append("track", ctx.song);
+		searchUrl.searchParams.append("artist", ctx.artist);
+		searchUrl.searchParams.append("duration", String(Math.round(ctx.duration)));
+		if (ctx.album) searchUrl.searchParams.append("album", ctx.album);
+
+		const searchResponse = await fetch(searchUrl.toString(), { signal: signal() });
+		if (!searchResponse.ok) return null;
+
+		const searchData = await searchResponse.json();
+		const selected: BinimumResult | undefined = searchData.results?.[0];
+		if (!selected?.lyricsUrl) return null;
+
+		const ttmlResponse = await fetch(selected.lyricsUrl, { signal: signal() });
+		if (!ttmlResponse.ok) return null;
+
+		const lyrics = TTMLParser.parse(await ttmlResponse.text());
+		if (lyrics.length === 0) return null;
+
+		return {
+			lyrics,
+			source: "BiniLyrics",
+			sourceHref: "https://lyrics-api.binimum.org/",
+			cacheAllowed: true,
+		};
+	};
+}

--- a/packages/provider-blyrics/src/providers/portato.ts
+++ b/packages/provider-blyrics/src/providers/portato.ts
@@ -1,0 +1,44 @@
+import { parseQRC } from "@braccato/parsers";
+import type { LyricSourceResult, ProviderFn } from "../types.js";
+
+const DEFAULT_API_URL = "https://lyrics-api.boidu.dev/qq/getLyrics";
+
+export interface PortatoProviderOptions {
+	apiUrl?: string;
+	timeout?: number;
+}
+
+export function createPortatoProvider(options: PortatoProviderOptions = {}): ProviderFn {
+	const { apiUrl = DEFAULT_API_URL, timeout = 10000 } = options;
+
+	return async (ctx): Promise<LyricSourceResult | null> => {
+		const url = new URL(apiUrl);
+		url.searchParams.append("s", ctx.song);
+		url.searchParams.append("a", ctx.artist);
+		url.searchParams.append("d", String(ctx.duration));
+		if (ctx.album) url.searchParams.append("al", ctx.album);
+
+		const response = await fetch(url.toString(), {
+			signal: AbortSignal.any([ctx.signal, AbortSignal.timeout(timeout)]),
+		});
+
+		if (!response.ok) return null;
+
+		const data = await response.json();
+		if (!data.lyrics || data.error) return null;
+
+		const lyrics = parseQRC(data.lyrics, ctx.duration * 1000, {
+			title: ctx.song,
+			artist: ctx.artist,
+		});
+		if (lyrics.length === 0) return null;
+
+		return {
+			lyrics,
+			source: "Better Lyrics Portato",
+			sourceHref: "https://boidu.dev/",
+			musicVideoSynced: false,
+			cacheAllowed: true,
+		};
+	};
+}

--- a/packages/provider-blyrics/src/providers/unison.ts
+++ b/packages/provider-blyrics/src/providers/unison.ts
@@ -1,0 +1,64 @@
+import { LRCParser, type Lyric, PlainParser, TTMLParser } from "@braccato/parsers";
+import type { LyricSourceResult, ProviderFn } from "../types.js";
+
+const DEFAULT_API_URL = "https://unison.boidu.dev/lyrics";
+const DEFAULT_SOURCE_HREF = "https://unison.boidu.dev/";
+
+interface UnisonData {
+	format?: "ttml" | "lrc" | "plain";
+	lyrics?: string;
+}
+
+export interface UnisonProviderOptions {
+	apiUrl?: string;
+	sourceHref?: string;
+	keyId?: string;
+	timeout?: number;
+}
+
+export function createUnisonProvider(options: UnisonProviderOptions = {}): ProviderFn {
+	const { apiUrl = DEFAULT_API_URL, sourceHref = DEFAULT_SOURCE_HREF, keyId, timeout = 10000 } = options;
+
+	return async (ctx): Promise<LyricSourceResult | null> => {
+		const url = new URL(apiUrl);
+		if (ctx.videoId) url.searchParams.append("v", ctx.videoId);
+		url.searchParams.append("song", ctx.song);
+		url.searchParams.append("artist", ctx.artist);
+		url.searchParams.append("duration", String(Math.round(ctx.duration)));
+		if (ctx.album) url.searchParams.append("album", ctx.album);
+
+		const response = await fetch(url.toString(), {
+			headers: keyId ? { "x-key-id": keyId } : undefined,
+			signal: AbortSignal.any([ctx.signal, AbortSignal.timeout(timeout)]),
+		});
+
+		if (!response.ok) return null;
+
+		const data: UnisonData | undefined = await response.json().then((json) => json?.data);
+		if (!data?.format || !data.lyrics) return null;
+
+		let lyrics: Lyric[];
+		switch (data.format) {
+			case "ttml":
+				lyrics = TTMLParser.parse(data.lyrics);
+				break;
+			case "lrc":
+				lyrics = LRCParser.parse(data.lyrics, ctx.duration * 1000);
+				break;
+			case "plain":
+				lyrics = PlainParser.parse(data.lyrics);
+				break;
+			default:
+				return null;
+		}
+
+		if (lyrics.length === 0) return null;
+
+		return {
+			lyrics,
+			source: "Unison",
+			sourceHref,
+			cacheAllowed: false,
+		};
+	};
+}

--- a/packages/provider-blyrics/src/types.ts
+++ b/packages/provider-blyrics/src/types.ts
@@ -22,6 +22,7 @@ export interface ProviderContext {
 	artist: string;
 	duration: number;
 	album?: string | null;
+	videoId?: string;
 	signal: AbortSignal;
 }
 


### PR DESCRIPTION
## Overview

Ported three more lyric sources into the provider chain: Unison, BiniLyrics, and Portato (QQ). Each hits its direct REST endpoint and hands the response to the parser it needs: Unison switches on its format field across TTML, LRC, and plain, BiniLyrics searches then fetches the matched TTML, and Portato parses QRC. Unison keys on a video id, so the provider context gains an optional videoId. Musixmatch and the two YouTube sources stayed out: no clean direct endpoint for the first, and the others need player data only the extension can sniff. Tests cover the new three and backfill the existing providers, and I ran all three against live endpoints to confirm they parse.
