### PR TITLE
perf(core): mark lettered highlight words with a class instead of :has()

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@braccato/core",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Synchronized lyrics renderer with word-by-word animations",
   "type": "module",
   "license": "MIT",

--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -34,6 +34,7 @@ export const BACKGROUND_LINE_CLASS = "blyrics-background-line" as const;
 export const WORD_GROUP_CLASS = "blyrics-word-group" as const;
 export const LONG_WORD_GROUP_CLASS = "blyrics-word-group-long" as const;
 export const WORD_HIGHLIGHT_CLASS = "blyrics-word-highlight" as const;
+export const WORD_HIGHLIGHT_LETTERED_CLASS = "blyrics-word-highlight--lettered" as const;
 export const HIGHLIGHT_RUN_CLASS = "blyrics-highlight-run" as const;
 export const LINE_SYNCED_WORD_CLASS = "blyrics-line-synced-word" as const;
 export const BIDI_RUN_CLASS = "blyrics-bidi-run" as const;

--- a/packages/core/src/inject.selfcheck.ts
+++ b/packages/core/src/inject.selfcheck.ts
@@ -8,6 +8,7 @@ import {
   WORD_CLASS,
   WORD_GROUP_CLASS,
   WORD_HIGHLIGHT_CLASS,
+  WORD_HIGHLIGHT_LETTERED_CLASS,
 } from "./constants";
 import { addSeekHandler, createLyricsLine, injectRomanization, injectTranslation, newLineData } from "./inject";
 import { createInstrumentalElement } from "./instrumental";
@@ -116,6 +117,11 @@ assert.equal(
   3,
   "Given three timed words, When the line is built, Then every word has the same real highlight target"
 );
+assert.equal(
+  highlights.some(node => node.classList.contains(WORD_HIGHLIGHT_LETTERED_CLASS)),
+  false,
+  "Given letter wave off, When a highlight word is built, Then it stays unlettered and keeps its swipe gradient"
+);
 assert.ok(
   wrappedHighlight?.parentNode?.classList.contains(WORD_GROUP_CLASS),
   "Given a wrapping highlight, When it is built, Then its matching highlight group owns it"
@@ -211,6 +217,19 @@ assert.equal(
   waveNodes.some(node => node.name === "wbr"),
   false,
   "Given letter wave on, When a word is built, Then the wrap-break path does not also run"
+);
+
+const waveHighlights = waveNodes.filter(node => node.classList.contains(WORD_HIGHLIGHT_CLASS));
+assert.ok(
+  waveHighlights.length > 0 && waveHighlights.every(node => node.classList.contains(WORD_HIGHLIGHT_LETTERED_CLASS)),
+  "Given letter wave on, When a highlight word is split into letters, Then it carries the lettered class the swipe-off rule selects"
+);
+assert.equal(
+  waveNodes.some(
+    node => node.classList.contains(WORD_HIGHLIGHT_LETTERED_CLASS) && !node.classList.contains(WORD_HIGHLIGHT_CLASS)
+  ),
+  false,
+  "Given letter wave on, When words are built, Then the lettered class marks only the highlight run"
 );
 
 setThemeSettings(new Map());

--- a/packages/core/src/inject.ts
+++ b/packages/core/src/inject.ts
@@ -30,6 +30,7 @@ import {
   WORD_CLASS,
   WORD_GROUP_CLASS,
   WORD_HIGHLIGHT_CLASS,
+  WORD_HIGHLIGHT_LETTERED_CLASS,
   ZERO_DURATION_ANIMATION_CLASS,
 } from "./constants";
 import { getSeekTimeFromClick } from "./seek";
@@ -361,8 +362,12 @@ function createTimedWordSpan(
 
     if (perLetter) {
       const collected = appendLetters(doc, wordElement, part.words);
-      if (wordElement === span) letters = collected;
-      else highlightLetters = collected;
+      if (wordElement === span) {
+        letters = collected;
+      } else {
+        highlightLetters = collected;
+        wordElement.classList.add(WORD_HIGHLIGHT_LETTERED_CLASS);
+      }
     } else {
       appendLongWordBreaks(doc, wordElement, part.words, wrapThreshold);
     }

--- a/packages/core/src/styles/lyrics.css
+++ b/packages/core/src/styles/lyrics.css
@@ -160,7 +160,7 @@
 	display: inline-block;
 }
 
-.blyrics-word-highlight:has(.blyrics--letter) {
+.blyrics-word-highlight.blyrics-word-highlight--lettered {
 	background-image: none;
 }
 


### PR DESCRIPTION
## Overview

The `.blyrics-word-highlight:has(.blyrics--letter)` rule re-scanned the letter subtree on every lyric mutation just to drop the swipe gradient on words split into letters. The builder already knows when it splits a word, so it now tags the highlight run with a class and the stylesheet keys off that. Same pixels, no scan.
