### PR TITLE
fix(core): read scroll position live each tick so autoscroll stays synced

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@braccato/core",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "Synchronized lyrics renderer with word-by-word animations",
   "type": "module",
   "license": "MIT",

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -183,8 +183,6 @@ export interface AnimationEngineInstance extends AnimEngineViewState {
   window: EngineWindow;
   host: LyricsRendererHost;
   cachedTabRendererHeight: number | null;
-  cachedMaxScrollTop: number | null;
-  cachedScrollTop: number | null;
   cachedFooterItem: LineScrollItem | null;
   cachedLineScrollTiming: Map<string, LineScrollTiming>;
   tabRendererResizeObserver: ResizeObserver | null;
@@ -268,8 +266,6 @@ export function createAnimationEngineInstance(
     passiveScrollAccumulatedTime: 0,
     passiveLastWallTime: 0,
     cachedTabRendererHeight: null,
-    cachedMaxScrollTop: null,
-    cachedScrollTop: null,
     cachedFooterItem: null,
     cachedLineScrollTiming: new Map(),
     tabRendererResizeObserver: null,
@@ -2712,7 +2708,6 @@ function passiveScrollEngine(engine: AnimationEngineInstance, isPlaying: boolean
   const prevScrollTop = tabRenderer.scrollTop;
   tabRenderer.scrollTop = targetScroll;
   const appliedScrollTop = tabRenderer.scrollTop;
-  engine.cachedScrollTop = appliedScrollTop;
   // Only skip the next scroll event if scrollTop actually changed.
   // When it doesn't change (pause phases, sub-pixel rounding), no programmatic
   // scroll event fires, so setting skipScrolls would eat user scroll events instead.
@@ -2734,21 +2729,12 @@ function setupTabRendererObserver(engine: AnimationEngineInstance, element: HTML
     dropPendingLineScroll(engine);
     if (element && element.isConnected) {
       engine.cachedTabRendererHeight = element.getBoundingClientRect().height;
-      refreshScrollMetrics(engine, element);
     }
   });
 
   engine.tabRendererResizeObserver.observe(element);
   engine.observedTabRenderer = element;
   engine.cachedTabRendererHeight = element.getBoundingClientRect().height;
-  refreshScrollMetrics(engine, element);
-}
-
-// Scroll position and bounds are cached here (and refreshed where layout is measured on purpose) so
-// the tick never reads them off the DOM, which would force a synchronous layout flush mid-frame.
-function refreshScrollMetrics(engine: AnimationEngineInstance, tabRenderer: HTMLElement): void {
-  engine.cachedMaxScrollTop = Math.max(0, tabRenderer.scrollHeight - tabRenderer.clientHeight);
-  engine.cachedScrollTop = tabRenderer.scrollTop;
 }
 
 /**
@@ -2879,14 +2865,9 @@ export function tickView(
       setupTabRendererObserver(engine, tabRenderer);
     }
     const tabRendererHeight = engine.cachedTabRendererHeight ?? tabRenderer.getBoundingClientRect().height;
-    // Read scroll position and bounds live here, before the loop below writes any class change, so the
-    // read costs no mid-frame reflow. Translation injection, re-measure, font load and layout shifts
-    // move scrollTop and scrollHeight without resizing the container, so the ResizeObserver never fires
-    // and a cached value would go stale and desync autoscroll until the user scrolled.
+    // Read before the loop's class writes so this layout read is batched and forces no mid-frame reflow.
     let scrollTop = tabRenderer.scrollTop;
-    engine.cachedScrollTop = scrollTop;
     const maxScrollTop = Math.max(0, tabRenderer.scrollHeight - tabRenderer.clientHeight);
-    engine.cachedMaxScrollTop = maxScrollTop;
     if (animationConfig.enabled.scroll) {
       updateVisibleLyricWillChange(
         engine,
@@ -3250,7 +3231,6 @@ export function tickView(
           scrollTop = scrollPos;
           engine.scrollPos = scrollTop;
           tabRenderer.scrollTop = scrollTop;
-          engine.cachedScrollTop = scrollTop;
           engine.skipScrolls += 1;
           engine.skipScrollsDecayTimes.push(Date.now() + 2000);
         } else if (engine.nextScrollAllowedTime - Date.now() < scrollTiming.queueScrollMs || timeJumped) {
@@ -3409,9 +3389,6 @@ export function relayout(engine: AnimationEngineInstance, measureLines: boolean)
 
   // Re-arm from the fresh measurements, so a line skipped after this holds its new placeholder height.
   setupLineCullObserver(engine);
-
-  const tabRenderer = engine.host.getScrollElement();
-  if (tabRenderer) refreshScrollMetrics(engine, tabRenderer);
 
   engine.wasUserScrolling = true; // trigger rescrolls
   engine.host.debug?.resize();

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -2879,16 +2879,14 @@ export function tickView(
       setupTabRendererObserver(engine, tabRenderer);
     }
     const tabRendererHeight = engine.cachedTabRendererHeight ?? tabRenderer.getBoundingClientRect().height;
-    // Read the DOM position only while the user scrolls (they own it then); otherwise reuse the cached
-    // value the engine last wrote, so the tick never forces a mid-frame layout flush.
-    let scrollTop: number;
-    if (engine.scrollResumeTime >= now || engine.cachedScrollTop === null) {
-      scrollTop = tabRenderer.scrollTop;
-      engine.cachedScrollTop = scrollTop;
-    } else {
-      scrollTop = engine.cachedScrollTop;
-    }
-    const maxScrollTop = engine.cachedMaxScrollTop ?? Math.max(0, tabRenderer.scrollHeight - tabRenderer.clientHeight);
+    // Read scroll position and bounds live here, before the loop below writes any class change, so the
+    // read costs no mid-frame reflow. Translation injection, re-measure, font load and layout shifts
+    // move scrollTop and scrollHeight without resizing the container, so the ResizeObserver never fires
+    // and a cached value would go stale and desync autoscroll until the user scrolled.
+    let scrollTop = tabRenderer.scrollTop;
+    engine.cachedScrollTop = scrollTop;
+    const maxScrollTop = Math.max(0, tabRenderer.scrollHeight - tabRenderer.clientHeight);
+    engine.cachedMaxScrollTop = maxScrollTop;
     if (animationConfig.enabled.scroll) {
       updateVisibleLyricWillChange(
         engine,


### PR DESCRIPTION
## Overview

PR #18 swapped the live scroll read in the render tick for a cache, assuming the engine is the only thing that ever moves scrollTop. It isn't. Async translation injection, line re-measure, font load, and fullscreen toggles all shift scrollTop and scrollHeight while the container box stays the same size, so the ResizeObserver never fires and the cache goes stale. The tick then measures its scroll delta against a position that no longer exists, and autoscroll jumps around until you scroll by hand. Read the position live again, once at tick start before any write so there's no mid-frame reflow. Every other #18 optimization stays put. Core goes to 1.6.2.
