### PR TITLE
fix(core): stop line culling from pausing autoscroll on Firefox

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@braccato/core",
-  "version": "1.6.2",
+  "version": "1.6.3",
   "description": "Synchronized lyrics renderer with word-by-word animations",
   "type": "module",
   "license": "MIT",

--- a/packages/core/src/engine.selfcheck.ts
+++ b/packages/core/src/engine.selfcheck.ts
@@ -62,6 +62,13 @@ const PLAYBACK_TIME_S = 0.2;
 // browser does: silently, which is what a module aiming past the end of its content relies on.
 class FakeScrollElement {
   private currentScrollTop = 0;
+  private readonly styleProperties: Record<string, string> = {};
+  readonly style = {
+    setProperty: (name: string, value: string): void => {
+      this.styleProperties[name] = value;
+    },
+    getPropertyValue: (name: string): string => this.styleProperties[name] ?? "",
+  };
 
   constructor(
     readonly viewportHeight: number,
@@ -816,6 +823,11 @@ assert.equal(
   cullLines.length,
   "Given lyrics are set, When the culling observer arms, Then it observes every line"
 );
+assert.equal(
+  cullHost.scrollElement.style.getPropertyValue("overflow-anchor"),
+  "none",
+  "Given culling arms, When the observer is set up, Then scroll anchoring is disabled on the container so a cull height-shift cannot fire a scroll the engine misreads as the user's"
+);
 for (const line of cullLines) {
   assert.notEqual(
     line.style.getPropertyValue("contain-intrinsic-block-size"),
@@ -866,7 +878,8 @@ assert.equal(
 // A window without an IntersectionObserver leaves every line rendered rather than failing.
 const noCullDocument = new FakeDocument();
 const noCullWindow = new FakeWindow(PANEL_STYLE);
-const noCullEngine = createAnimationEngineInstance(asDocument(noCullDocument), asWindow(noCullWindow), new FakeHost());
+const noCullHost = new FakeHost();
+const noCullEngine = createAnimationEngineInstance(asDocument(noCullDocument), asWindow(noCullWindow), noCullHost);
 const noCullMount = noCullDocument.createElement("div");
 setLyrics(noCullEngine, asElement<HTMLElement>(noCullMount), LINE_SYNCED_LYRICS, {
   loaderVisible: false,
@@ -876,6 +889,11 @@ assert.equal(
   noCullWindow.intersectionObservers.length,
   0,
   "Given a window with no IntersectionObserver, When lyrics are set, Then culling arms nothing and the lines render"
+);
+assert.equal(
+  noCullHost.scrollElement.style.getPropertyValue("overflow-anchor"),
+  "",
+  "Given no IntersectionObserver, When culling cannot arm, Then anchoring is left untouched because no cull height-shift occurs"
 );
 setupLineCullObserver(noCullEngine); // safe to call directly with no observer support
 clearLyrics(noCullEngine);

--- a/packages/core/src/engine.ts
+++ b/packages/core/src/engine.ts
@@ -2268,6 +2268,9 @@ export function setupLineCullObserver(engine: AnimationEngineInstance): void {
     return;
   }
 
+  // Scroll anchoring would compensate residual cull height-shifts with a scroll the engine misreads as the user's (Firefox); the engine owns scrollTop, so disable it.
+  engine.host.getScrollElement()?.style.setProperty("overflow-anchor", "none");
+
   // Pin each line's skipped placeholder to its last rendered size, so skipping a line never shifts the
   // container's scroll height, which the engine would misread as a user scroll.
   const restingHeights = engine.lines.map(line => line.lyricElement.offsetHeight);


### PR DESCRIPTION
## Overview

Off-screen line culling shifts the scroller's content height by a pixel or two as lyrics move past, and Firefox's scroll anchoring reacts by nudging the scroll position back. That nudge fires a scroll event that looks just like the user's, so autoscroll pauses and the resume button shows up mid-song. Disable scroll anchoring on the container the engine already scrolls itself, so Firefox stops compensating. Chrome isn't affected, and culling keeps its perf win everywhere.
